### PR TITLE
Use Apache2 license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing Guidelines
+Thank you for your interest in contributing to `smacc`.
+Whether it's a bug report, new feature, correction, or additional
+documentation, we greatly value feedback and contributions from our community.
+
+Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
+information to effectively respond to your bug report or contribution.
+
+
+## Reporting Bugs/Feature Requests
+We welcome you to use the GitHub issue tracker to report bugs or suggest features.
+
+When filing an issue, please check [existing open][issues], or [recently closed][closed-issues], issues to make sure
+ somebody else hasn't already reported the issue.
+Please try to include as much information as you can. Details like these are incredibly useful:
+
+* A reproducible test case or series of steps
+* The version of our code being used
+* Any modifications you've made relevant to the bug
+* Anything unusual about your environment or deployment
+
+
+## Contributing via Pull Requests
+Contributions via pull requests are much appreciated.
+Before sending us a pull request, please ensure that:
+
+1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
+2. Give your PR a descriptive title. Add a short summary, if required.
+3. Make sure the pipeline is green.
+4. Don’t be afraid to request reviews from maintainers.
+5. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
+
+To send us a pull request, please:
+
+1. Fork the repository.
+2. Modify the source; please focus on the specific change you are contributing.
+  If you also reformat all the code, it will be hard for us to focus on your change.
+3. Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
+4. Commit to your fork using clear commit messages.
+5. Send a pull request, answering any default questions in the pull request interface.
+6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+
+GitHub provides additional documentation on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
+[creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
+
+
+## Finding contributions to work on
+Looking at the existing issues is a great way to find something to contribute on.
+As this project, by default, uses the default GitHub issue labels
+  (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'][help-wanted] issues
+  is a great place to start.
+
+
+## Licensing
+Any contribution that you make to this repository will be under the Apache 2 License, as dictated by that [license]:
+
+~~~
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+~~~
+
+[issues]: https://github.com/robosoft-ai/SMACC2/issues
+[closed-issues]: https://github.com/robosoft-ai/SMACC2/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20
+[help-wanted]: https://github.com/robosoft-ai/SMACC2/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22
+[license]: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/LICENSE
+++ b/LICENSE
@@ -1,29 +1,202 @@
-BSD 3-Clause License
 
-Copyright (c) 2020, droidware.ai
-All rights reserved.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
+   1. Definitions.
 
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/smacc2/include/smacc/client_base_components/cp_topic_subscriber.h
+++ b/smacc2/include/smacc/client_base_components/cp_topic_subscriber.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 #include <smacc/client_bases/smacc_subscriber_client.h>
 #include <smacc/component.h>

--- a/smacc2/include/smacc/client_bases/smacc_action_client.h
+++ b/smacc2/include/smacc/client_bases/smacc_action_client.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/client_bases/smacc_action_client_base.h
+++ b/smacc2/include/smacc/client_bases/smacc_action_client_base.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/client_bases/smacc_publisher_client.h
+++ b/smacc2/include/smacc/client_bases/smacc_publisher_client.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/client_bases/smacc_service_client.h
+++ b/smacc2/include/smacc/client_bases/smacc_service_client.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/client_bases/smacc_subscriber_client.h
+++ b/smacc2/include/smacc/client_bases/smacc_subscriber_client.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/client_behaviors/cb_subscription_callback_base.h
+++ b/smacc2/include/smacc/client_behaviors/cb_subscription_callback_base.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018-2021
+ *-2021
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/client_behaviors/cb_wait_action_server.h
+++ b/smacc2/include/smacc/client_behaviors/cb_wait_action_server.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 #include <smacc/client_bases/smacc_action_client_base.h>
 #include <smacc/smacc_asynchronous_client_behavior.h>

--- a/smacc2/include/smacc/common.h
+++ b/smacc2/include/smacc/common.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/component.h
+++ b/smacc2/include/smacc/component.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/impl/smacc_asynchronous_client_behavior_impl.h
+++ b/smacc2/include/smacc/impl/smacc_asynchronous_client_behavior_impl.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/impl/smacc_client_behavior_impl.h
+++ b/smacc2/include/smacc/impl/smacc_client_behavior_impl.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/impl/smacc_client_impl.h
+++ b/smacc2/include/smacc/impl/smacc_client_impl.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/impl/smacc_component_impl.h
+++ b/smacc2/include/smacc/impl/smacc_component_impl.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/impl/smacc_event_generator_impl.h
+++ b/smacc2/include/smacc/impl/smacc_event_generator_impl.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/impl/smacc_orthogonal_impl.h
+++ b/smacc2/include/smacc/impl/smacc_orthogonal_impl.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/impl/smacc_state_impl.h
+++ b/smacc2/include/smacc/impl/smacc_state_impl.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/impl/smacc_state_machine_impl.h
+++ b/smacc2/include/smacc/impl/smacc_state_machine_impl.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/impl/smacc_state_reactor_impl.h
+++ b/smacc2/include/smacc/impl/smacc_state_reactor_impl.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/introspection/introspection.h
+++ b/smacc2/include/smacc/introspection/introspection.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/introspection/smacc_state_info.h
+++ b/smacc2/include/smacc/introspection/smacc_state_info.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/introspection/smacc_state_machine_info.h
+++ b/smacc2/include/smacc/introspection/smacc_state_machine_info.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/introspection/smacc_type_info.h
+++ b/smacc2/include/smacc/introspection/smacc_type_info.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/introspection/state_traits.h
+++ b/smacc2/include/smacc/introspection/state_traits.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 namespace smacc

--- a/smacc2/include/smacc/smacc.h
+++ b/smacc2/include/smacc/smacc.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/smacc_asynchronous_client_behavior.h
+++ b/smacc2/include/smacc/smacc_asynchronous_client_behavior.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/smacc_client.h
+++ b/smacc2/include/smacc/smacc_client.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/smacc_client_behavior.h
+++ b/smacc2/include/smacc/smacc_client_behavior.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/smacc_client_behavior_base.h
+++ b/smacc2/include/smacc/smacc_client_behavior_base.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/smacc_default_events.h
+++ b/smacc2/include/smacc/smacc_default_events.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <smacc/smacc_types.h>

--- a/smacc2/include/smacc/smacc_event_generator.h
+++ b/smacc2/include/smacc/smacc_event_generator.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/smacc_fifo_scheduler.h
+++ b/smacc2/include/smacc/smacc_fifo_scheduler.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc_fifo_worker.h>
 #include <boost/statechart/fifo_scheduler.hpp>
 

--- a/smacc2/include/smacc/smacc_fifo_worker.h
+++ b/smacc2/include/smacc/smacc_fifo_worker.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 #include <boost/statechart/fifo_worker.hpp>
 

--- a/smacc2/include/smacc/smacc_orthogonal.h
+++ b/smacc2/include/smacc/smacc_orthogonal.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/smacc_signal.h
+++ b/smacc2/include/smacc/smacc_signal.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/smacc_signal_detector.h
+++ b/smacc2/include/smacc/smacc_signal_detector.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/smacc_state.h
+++ b/smacc2/include/smacc/smacc_state.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/smacc_state_base.h
+++ b/smacc2/include/smacc/smacc_state_base.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/smacc_state_machine.h
+++ b/smacc2/include/smacc/smacc_state_machine.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/smacc_state_machine_base.h
+++ b/smacc2/include/smacc/smacc_state_machine_base.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/smacc_state_reactor.h
+++ b/smacc2/include/smacc/smacc_state_reactor.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/smacc_tracing/smacc_tracing.h
+++ b/smacc2/include/smacc/smacc_tracing/smacc_tracing.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <tracetools/tracetools.h>
 
 #ifdef __cplusplus

--- a/smacc2/include/smacc/smacc_tracing/trace_provider.h
+++ b/smacc2/include/smacc/smacc_tracing/trace_provider.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // the pragma once does not work here
 // #pragma once
 

--- a/smacc2/include/smacc/smacc_transition.h
+++ b/smacc2/include/smacc/smacc_transition.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/smacc_types.h
+++ b/smacc2/include/smacc/smacc_types.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/include/smacc/smacc_updatable.h
+++ b/smacc2/include/smacc/smacc_updatable.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/package.xml
+++ b/smacc2/package.xml
@@ -9,7 +9,7 @@
   <author email="pablo@ibrobotics.com">Pablo Inigo Blasco</author>
   <author email="ba@leadtank.org">Brett Aldrich</author>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc2/src/smacc/client.cpp
+++ b/smacc2/src/smacc/client.cpp
@@ -1,6 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/src/smacc/client_bases/smacc_action_client.cpp
+++ b/smacc2/src/smacc/client_bases/smacc_action_client.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/src/smacc/client_bases/smacc_publisher_client.cpp
+++ b/smacc2/src/smacc/client_bases/smacc_publisher_client.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/src/smacc/client_behaviors/cb_wait_action_server.cpp
+++ b/smacc2/src/smacc/client_behaviors/cb_wait_action_server.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/client_behaviors/cb_wait_action_server.h>
 
 namespace smacc

--- a/smacc2/src/smacc/common.cpp
+++ b/smacc2/src/smacc/common.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/src/smacc/introspection/reflection.cpp
+++ b/smacc2/src/smacc/introspection/reflection.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/introspection/introspection.h>
 #include "rclcpp/rclcpp.hpp"
 

--- a/smacc2/src/smacc/introspection/string_type_walker.cpp
+++ b/smacc2/src/smacc/introspection/string_type_walker.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/introspection/smacc_type_info.h>
 
 #include <algorithm>

--- a/smacc2/src/smacc/orthogonal.cpp
+++ b/smacc2/src/smacc/orthogonal.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/impl/smacc_state_machine_impl.h>
 #include <smacc/smacc_client_behavior.h>
 #include <smacc/smacc_orthogonal.h>

--- a/smacc2/src/smacc/signal_detector.cpp
+++ b/smacc2/src/smacc/signal_detector.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/src/smacc/smacc_client_async_behavior.cpp
+++ b/smacc2/src/smacc/smacc_client_async_behavior.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc_asynchronous_client_behavior.h>
 
 using namespace std::chrono_literals;

--- a/smacc2/src/smacc/smacc_client_behavior.cpp
+++ b/smacc2/src/smacc/smacc_client_behavior.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc_client_behavior.h>
 
 namespace smacc

--- a/smacc2/src/smacc/smacc_client_behavior_base.cpp
+++ b/smacc2/src/smacc/smacc_client_behavior_base.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc_client_behavior.h>
 
 namespace smacc

--- a/smacc2/src/smacc/smacc_component.cpp
+++ b/smacc2/src/smacc/smacc_component.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/src/smacc/smacc_event_generator.cpp
+++ b/smacc2/src/smacc/smacc_event_generator.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/src/smacc/smacc_state.cpp
+++ b/smacc2/src/smacc/smacc_state.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc_state.h>
 #include <smacc/smacc_state_machine.h>
 

--- a/smacc2/src/smacc/smacc_state_info.cpp
+++ b/smacc2/src/smacc/smacc_state_info.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/common.h>
 #include <smacc/introspection/introspection.h>
 

--- a/smacc2/src/smacc/smacc_state_machine.cpp
+++ b/smacc2/src/smacc/smacc_state_machine.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc2/src/smacc/smacc_state_machine_info.cpp
+++ b/smacc2/src/smacc/smacc_state_machine_info.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/introspection/introspection.h>
 #include <smacc/smacc_state_machine.h>
 

--- a/smacc2/src/smacc/smacc_tracing.cpp
+++ b/smacc2/src/smacc/smacc_tracing.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc_tracing/smacc_tracing.h>
 
 #ifdef TRACETOOLS_LTTNG_ENABLED

--- a/smacc2/src/smacc/smacc_updatable.cpp
+++ b/smacc2/src/smacc/smacc_updatable.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc_updatable.h>
 
 namespace smacc

--- a/smacc2/src/smacc/state_reactor.cpp
+++ b/smacc2/src/smacc/state_reactor.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc_state.h>
 #include <smacc/smacc_state_reactor.h>
 #include "rclcpp/rclcpp.hpp"

--- a/smacc2/src/smacc/trace_provider.cpp
+++ b/smacc2/src/smacc/trace_provider.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #define TRACEPOINT_CREATE_PROBES
 #define TRACEPOINT_DEFINE
 

--- a/smacc2_ci/packagecloud_docker/generate_debs.py
+++ b/smacc2_ci/packagecloud_docker/generate_debs.py
@@ -1,3 +1,17 @@
+# Copyright 2021 RobosoftAI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # /bin/python
 
 import rospkg

--- a/smacc_client_library/keyboard_client/include/keyboard_client/cl_keyboard.h
+++ b/smacc_client_library/keyboard_client/include/keyboard_client/cl_keyboard.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <smacc/client_bases/smacc_subscriber_client.h>

--- a/smacc_client_library/keyboard_client/include/keyboard_client/client_behaviors/cb_default_keyboard_behavior.h
+++ b/smacc_client_library/keyboard_client/include/keyboard_client/client_behaviors/cb_default_keyboard_behavior.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <keyboard_client/cl_keyboard.h>

--- a/smacc_client_library/keyboard_client/package.xml
+++ b/smacc_client_library/keyboard_client/package.xml
@@ -5,7 +5,7 @@
   <version>2.9.1</version>
   <description>The keyboard_client package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc_client_library/keyboard_client/servers/keyboard_server_node.py
+++ b/smacc_client_library/keyboard_client/servers/keyboard_server_node.py
@@ -1,4 +1,19 @@
 #!/bin/env python3
+
+# Copyright 2021 RobosoftAI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import rclpy
 from rclpy.node import Node
 

--- a/smacc_client_library/keyboard_client/src/keyboard_client/cl_keyboard.cpp
+++ b/smacc_client_library/keyboard_client/src/keyboard_client/cl_keyboard.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <keyboard_client/cl_keyboard.h>
 
 namespace cl_keyboard

--- a/smacc_client_library/keyboard_client/src/keyboard_client/client_behaviors/cb_default_keyboard_behavior.cpp
+++ b/smacc_client_library/keyboard_client/src/keyboard_client/client_behaviors/cb_default_keyboard_behavior.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <keyboard_client/client_behaviors/cb_default_keyboard_behavior.h>
 
 namespace cl_keyboard

--- a/smacc_client_library/move_base_z_client/custom_planners/backward_global_planner/include/backward_global_planner/backward_global_planner.h
+++ b/smacc_client_library/move_base_z_client/custom_planners/backward_global_planner/include/backward_global_planner/backward_global_planner.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/custom_planners/backward_global_planner/src/backward_global_planner/backward_global_planner.cpp
+++ b/smacc_client_library/move_base_z_client/custom_planners/backward_global_planner/src/backward_global_planner/backward_global_planner.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/custom_planners/backward_local_planner/include/backward_local_planner/backward_local_planner.h
+++ b/smacc_client_library/move_base_z_client/custom_planners/backward_local_planner/include/backward_local_planner/backward_local_planner.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/custom_planners/backward_local_planner/src/backward_local_planner/backward_local_planner.cpp
+++ b/smacc_client_library/move_base_z_client/custom_planners/backward_local_planner/src/backward_local_planner/backward_local_planner.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <angles/angles.h>
 #include <backward_local_planner/backward_local_planner.h>
 #include <move_base_z_planners_common/common.h>

--- a/smacc_client_library/move_base_z_client/custom_planners/forward_global_planner/include/forward_global_planner/forward_global_planner.h
+++ b/smacc_client_library/move_base_z_client/custom_planners/forward_global_planner/include/forward_global_planner/forward_global_planner.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/custom_planners/forward_global_planner/src/forward_global_planner/forward_global_planner.cpp
+++ b/smacc_client_library/move_base_z_client/custom_planners/forward_global_planner/src/forward_global_planner/forward_global_planner.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/custom_planners/forward_local_planner/include/forward_local_planner/forward_local_planner.h
+++ b/smacc_client_library/move_base_z_client/custom_planners/forward_local_planner/include/forward_local_planner/forward_local_planner.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/custom_planners/forward_local_planner/src/forward_local_planner/forward_local_planner.cpp
+++ b/smacc_client_library/move_base_z_client/custom_planners/forward_local_planner/src/forward_local_planner/forward_local_planner.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/custom_planners/move_base_z_planners_common/include/move_base_z_planners_common/common.h
+++ b/smacc_client_library/move_base_z_client/custom_planners/move_base_z_planners_common/include/move_base_z_planners_common/common.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist.hpp>

--- a/smacc_client_library/move_base_z_client/custom_planners/move_base_z_planners_common/include/move_base_z_planners_common/move_base_z_client_tools.h
+++ b/smacc_client_library/move_base_z_client/custom_planners/move_base_z_planners_common/include/move_base_z_planners_common/move_base_z_client_tools.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/custom_planners/move_base_z_planners_common/src/move_base_z_planners_common/common.cpp
+++ b/smacc_client_library/move_base_z_client/custom_planners/move_base_z_planners_common/src/move_base_z_planners_common/common.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/custom_planners/pure_spinning_local_planner/include/pure_spinning_local_planner/pure_spinning_local_planner.h
+++ b/smacc_client_library/move_base_z_client/custom_planners/pure_spinning_local_planner/include/pure_spinning_local_planner/pure_spinning_local_planner.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/custom_planners/pure_spinning_local_planner/package.xml
+++ b/smacc_client_library/move_base_z_client/custom_planners/pure_spinning_local_planner/package.xml
@@ -7,7 +7,7 @@
 
   <maintainer email="pablo@ibrobotics.com">Pablo Iñigo Blasco</maintainer>
 
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>pluginlib</build_depend>

--- a/smacc_client_library/move_base_z_client/custom_planners/pure_spinning_local_planner/src/pure_spinning_local_planner/pure_spinning_local_planner.cpp
+++ b/smacc_client_library/move_base_z_client/custom_planners/pure_spinning_local_planner/src/pure_spinning_local_planner/pure_spinning_local_planner.cpp
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <angles/angles.h>
 #include <pure_spinning_local_planner/pure_spinning_local_planner.h>

--- a/smacc_client_library/move_base_z_client/custom_planners/undo_path_global_planner/include/undo_path_global_planner/undo_path_global_planner.h
+++ b/smacc_client_library/move_base_z_client/custom_planners/undo_path_global_planner/include/undo_path_global_planner/undo_path_global_planner.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/custom_planners/undo_path_global_planner/src/undo_path_global_planner/undo_path_global_planner.cpp
+++ b/smacc_client_library/move_base_z_client/custom_planners/undo_path_global_planner/src/undo_path_global_planner/undo_path_global_planner.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/amcl_client.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/amcl_client.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 #include <move_base_z_client_plugin/client_behaviors/cb_absolute_rotate.h>
 #include <move_base_z_client_plugin/client_behaviors/cb_navigate_backwards.h>

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_absolute_rotate.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_absolute_rotate.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_move_base_client_behavior_base.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_move_base_client_behavior_base.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_navigate_backwards.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_navigate_backwards.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_navigate_forward.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_navigate_forward.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_navigate_global_position.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_navigate_global_position.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_navigate_next_waypoint.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_navigate_next_waypoint.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_rotate.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_rotate.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_undo_path_backwards.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_undo_path_backwards.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_wait_pose.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/client_behaviors/cb_wait_pose.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/common.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/common.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <builtin_interfaces/msg/time.hpp>

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/components/costmap_switch/cp_costmap_switch.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/components/costmap_switch/cp_costmap_switch.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/components/goal_checker_switcher/goal_checker_switcher.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/components/goal_checker_switcher/goal_checker_switcher.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/components/odom_tracker/odom_tracker.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/components/odom_tracker/odom_tracker.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/components/planner_switcher/planner_switcher.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/components/planner_switcher/planner_switcher.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/components/pose/cp_pose.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/components/pose/cp_pose.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018-2020
+ *-2020
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/components/waypoints_navigator/waypoints_event_dispatcher.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/components/waypoints_navigator/waypoints_event_dispatcher.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/components/waypoints_navigator/waypoints_navigator.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/components/waypoints_navigator/waypoints_navigator.h
@@ -1,6 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/move_base_z_client_plugin.h
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/include/move_base_z_client_plugin/move_base_z_client_plugin.h
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_absolute_rotate.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_absolute_rotate.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_move_base_client_behavior_base.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_move_base_client_behavior_base.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_navigate_backward.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_navigate_backward.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_navigate_forward.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_navigate_forward.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_navigate_global_position.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_navigate_global_position.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_navigate_next_waypoint.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_navigate_next_waypoint.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_rotate.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_rotate.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_undo_path_backwards.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_undo_path_backwards.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_wait_pose.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/client_behaviors/cb_wait_pose.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/common.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/common.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <move_base_z_client_plugin/common.h>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/components/costmap_switch/cp_costmap_switch.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/components/costmap_switch/cp_costmap_switch.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <move_base_z_client_plugin/components/costmap_switch/cp_costmap_switch.h>
 
 namespace cl_move_base_z

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/components/goal_checker_switcher/goal_checker_switcher.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/components/goal_checker_switcher/goal_checker_switcher.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/components/odom_tracker/odom_tracker.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/components/odom_tracker/odom_tracker.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/components/odom_tracker/odom_tracker_node.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/components/odom_tracker/odom_tracker_node.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/components/planner_switcher/planner_switcher.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/components/planner_switcher/planner_switcher.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/components/pose/cp_pose.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/components/pose/cp_pose.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/components/waypoints_navigator/waypoints_event_dispatcher.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/components/waypoints_navigator/waypoints_event_dispatcher.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <move_base_z_client_plugin/components/waypoints_navigator/waypoints_event_dispatcher.h>
 
 namespace cl_move_base_z

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/components/waypoints_navigator/waypoints_navigator.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/components/waypoints_navigator/waypoints_navigator.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <move_base_z_client_plugin/common.h>
 #include <move_base_z_client_plugin/components/goal_checker_switcher/goal_checker_switcher.h>
 #include <move_base_z_client_plugin/components/odom_tracker/odom_tracker.h>

--- a/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/move_base_z_client_plugin.cpp
+++ b/smacc_client_library/move_base_z_client/move_base_z_client_plugin/src/move_base_z_client_plugin/move_base_z_client_plugin.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_client_library/multirole_sensor_client/include/multirole_sensor_client/cl_multirole_sensor.h
+++ b/smacc_client_library/multirole_sensor_client/include/multirole_sensor_client/cl_multirole_sensor.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <smacc/client_bases/smacc_subscriber_client.h>

--- a/smacc_client_library/multirole_sensor_client/include/multirole_sensor_client/client_behaviors/cb_default_multirole_sensor_behavior.h
+++ b/smacc_client_library/multirole_sensor_client/include/multirole_sensor_client/client_behaviors/cb_default_multirole_sensor_behavior.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <multirole_sensor_client/cl_multirole_sensor.h>

--- a/smacc_client_library/multirole_sensor_client/package.xml
+++ b/smacc_client_library/multirole_sensor_client/package.xml
@@ -5,7 +5,7 @@
   <version>0.9.1</version>
   <description>The multirole_sensor_client package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Iñigo Blasco</maintainer>
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc_client_library/multirole_sensor_client/src/multirole_sensor_client/cl_multirole_sensor.cpp
+++ b/smacc_client_library/multirole_sensor_client/src/multirole_sensor_client/cl_multirole_sensor.cpp
@@ -1,2 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <multirole_sensor_client/cl_multirole_sensor.h>
 #include <multirole_sensor_client/client_behaviors/cb_default_multirole_sensor_behavior.h>

--- a/smacc_client_library/ros_publisher_client/include/ros_publisher_client/cl_ros_publisher.h
+++ b/smacc_client_library/ros_publisher_client/include/ros_publisher_client/cl_ros_publisher.h
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 

--- a/smacc_client_library/ros_publisher_client/include/ros_publisher_client/client_behaviors/cb_default_publish_loop.h
+++ b/smacc_client_library/ros_publisher_client/include/ros_publisher_client/client_behaviors/cb_default_publish_loop.h
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 #include <ros_publisher_client/cl_ros_publisher.h>

--- a/smacc_client_library/ros_publisher_client/include/ros_publisher_client/client_behaviors/cb_muted_behavior.h
+++ b/smacc_client_library/ros_publisher_client/include/ros_publisher_client/client_behaviors/cb_muted_behavior.h
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 #include <ros_publisher_client/cl_ros_publisher.h>

--- a/smacc_client_library/ros_publisher_client/include/ros_publisher_client/client_behaviors/cb_publish_once.h
+++ b/smacc_client_library/ros_publisher_client/include/ros_publisher_client/client_behaviors/cb_publish_once.h
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 #include <ros_publisher_client/cl_ros_publisher.h>

--- a/smacc_client_library/ros_publisher_client/package.xml
+++ b/smacc_client_library/ros_publisher_client/package.xml
@@ -5,7 +5,7 @@
   <version>2.9.1</version>
   <description>The ros_publisher_client package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc_client_library/ros_publisher_client/src/cl_ros_publisher_client.cpp
+++ b/smacc_client_library/ros_publisher_client/src/cl_ros_publisher_client.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <ros_publisher_client/cl_ros_publisher.h>
 
 namespace cl_ros_publisher

--- a/smacc_client_library/ros_timer_client/include/include/ros_timer_client/cl_ros_timer.h
+++ b/smacc_client_library/ros_timer_client/include/include/ros_timer_client/cl_ros_timer.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <smacc/smacc.h>

--- a/smacc_client_library/ros_timer_client/include/include/ros_timer_client/client_behaviors/cb_ros_timer.h
+++ b/smacc_client_library/ros_timer_client/include/include/ros_timer_client/client_behaviors/cb_ros_timer.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <ros_timer_client/cl_ros_timer.h>

--- a/smacc_client_library/ros_timer_client/include/include/ros_timer_client/client_behaviors/cb_timer_countdown_loop.h
+++ b/smacc_client_library/ros_timer_client/include/include/ros_timer_client/client_behaviors/cb_timer_countdown_loop.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <ros_timer_client/cl_ros_timer.h>

--- a/smacc_client_library/ros_timer_client/include/include/ros_timer_client/client_behaviors/cb_timer_countdown_once.h
+++ b/smacc_client_library/ros_timer_client/include/include/ros_timer_client/client_behaviors/cb_timer_countdown_once.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <ros_timer_client/cl_ros_timer.h>

--- a/smacc_client_library/ros_timer_client/include/ros_timer_client/cl_ros_timer.h
+++ b/smacc_client_library/ros_timer_client/include/ros_timer_client/cl_ros_timer.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <smacc/smacc.h>

--- a/smacc_client_library/ros_timer_client/include/ros_timer_client/client_behaviors/cb_ros_timer.h
+++ b/smacc_client_library/ros_timer_client/include/ros_timer_client/client_behaviors/cb_ros_timer.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <ros_timer_client/cl_ros_timer.h>

--- a/smacc_client_library/ros_timer_client/include/ros_timer_client/client_behaviors/cb_timer_countdown_loop.h
+++ b/smacc_client_library/ros_timer_client/include/ros_timer_client/client_behaviors/cb_timer_countdown_loop.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <ros_timer_client/cl_ros_timer.h>

--- a/smacc_client_library/ros_timer_client/include/ros_timer_client/client_behaviors/cb_timer_countdown_once.h
+++ b/smacc_client_library/ros_timer_client/include/ros_timer_client/client_behaviors/cb_timer_countdown_once.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <ros_timer_client/cl_ros_timer.h>

--- a/smacc_client_library/ros_timer_client/package.xml
+++ b/smacc_client_library/ros_timer_client/package.xml
@@ -5,7 +5,7 @@
   <version>2.9.1</version>
   <description>The ros_timer_client package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc_client_library/ros_timer_client/src/ros_timer_client/cb_timer.cpp
+++ b/smacc_client_library/ros_timer_client/src/ros_timer_client/cb_timer.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <ros_timer_client/client_behaviors/cb_ros_timer.h>
 
 namespace cl_ros_timer

--- a/smacc_client_library/ros_timer_client/src/ros_timer_client/cb_timer_countdown_loop.cpp
+++ b/smacc_client_library/ros_timer_client/src/ros_timer_client/cb_timer_countdown_loop.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <ros_timer_client/client_behaviors/cb_timer_countdown_loop.h>
 
 namespace cl_ros_timer

--- a/smacc_client_library/ros_timer_client/src/ros_timer_client/cb_timer_countdown_once.cpp
+++ b/smacc_client_library/ros_timer_client/src/ros_timer_client/cb_timer_countdown_once.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <ros_timer_client/client_behaviors/cb_timer_countdown_once.h>
 
 namespace cl_ros_timer

--- a/smacc_client_library/ros_timer_client/src/ros_timer_client/timer_client.cpp
+++ b/smacc_client_library/ros_timer_client/src/ros_timer_client/timer_client.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <ros_timer_client/cl_ros_timer.h>
 
 namespace cl_ros_timer

--- a/smacc_event_generators/eg_conditional_generator/include/eg_conditional_generator/eg_conditional_generator.h
+++ b/smacc_event_generators/eg_conditional_generator/include/eg_conditional_generator/eg_conditional_generator.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 #include <smacc/common.h>
 #include <smacc/smacc_event_generator.h>

--- a/smacc_event_generators/eg_conditional_generator/package.xml
+++ b/smacc_event_generators/eg_conditional_generator/package.xml
@@ -6,7 +6,7 @@
   <description>The eg_random_generator package</description>
 
   <maintainer email="pablo@ibrobotics.com">Pablo Iñigo Blasco</maintainer>
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc_event_generators/eg_conditional_generator/src/eg_conditional_generator/eg_conditional_generator.cpp
+++ b/smacc_event_generators/eg_conditional_generator/src/eg_conditional_generator/eg_conditional_generator.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <eg_conditional_generator/eg_conditional_generator.h>
 
 namespace smacc

--- a/smacc_event_generators/eg_random_generator/include/eg_random_generator/eg_random_generator.h
+++ b/smacc_event_generators/eg_random_generator/include/eg_random_generator/eg_random_generator.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 #include <smacc/common.h>
 #include <smacc/smacc_event_generator.h>

--- a/smacc_event_generators/eg_random_generator/package.xml
+++ b/smacc_event_generators/eg_random_generator/package.xml
@@ -5,7 +5,7 @@
    <version>2.9.1</version>
    <description>The eg_random_generator package</description>
    <maintainer email="pablo@ibrobotics.com">Pablo Iñigo Blasco</maintainer>
-   <license>BSD-3</license>
+   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc_event_generators/eg_random_generator/src/eg_random_generator/eg_random_generator.cpp
+++ b/smacc_event_generators/eg_random_generator/src/eg_random_generator/eg_random_generator.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <eg_random_generator/eg_random_generator.h>
 
 namespace smacc

--- a/smacc_sm_reference_library/sm_atomic/include/sm_atomic/orthogonals/or_timer.h
+++ b/smacc_sm_reference_library/sm_atomic/include/sm_atomic/orthogonals/or_timer.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <ros_timer_client/cl_ros_timer.h>
 #include <smacc/smacc.h>
 #include <chrono>

--- a/smacc_sm_reference_library/sm_atomic/include/sm_atomic/sm_atomic.h
+++ b/smacc_sm_reference_library/sm_atomic/include/sm_atomic/sm_atomic.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 // CLIENTS

--- a/smacc_sm_reference_library/sm_atomic/include/sm_atomic/states/st_state_1.h
+++ b/smacc_sm_reference_library/sm_atomic/include/sm_atomic/states/st_state_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 namespace sm_atomic

--- a/smacc_sm_reference_library/sm_atomic/include/sm_atomic/states/st_state_2.h
+++ b/smacc_sm_reference_library/sm_atomic/include/sm_atomic/states/st_state_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 namespace sm_atomic

--- a/smacc_sm_reference_library/sm_atomic/launch/sm_atomic.py
+++ b/smacc_sm_reference_library/sm_atomic/launch/sm_atomic.py
@@ -1,3 +1,17 @@
+# Copyright 2021 RobosoftAI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from launch import LaunchDescription
 from launch_ros.actions import Node
 

--- a/smacc_sm_reference_library/sm_atomic/package.xml
+++ b/smacc_sm_reference_library/sm_atomic/package.xml
@@ -5,7 +5,7 @@
   <version>2.9.1</version>
   <description>The sm_atomic package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc_sm_reference_library/sm_atomic/src/sm_atomic/sm_atomic_node.cpp
+++ b/smacc_sm_reference_library/sm_atomic/src/sm_atomic/sm_atomic_node.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <sm_atomic/sm_atomic.h>
 
 //--------------------------------------------------------------------

--- a/smacc_sm_reference_library/sm_atomic_performance_test/include/sm_atomic_performance_test/sm_atomic_performance_test.h
+++ b/smacc_sm_reference_library/sm_atomic_performance_test/include/sm_atomic_performance_test/sm_atomic_performance_test.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 using namespace boost;

--- a/smacc_sm_reference_library/sm_atomic_performance_test/include/sm_atomic_performance_test/states/st_state_1.h
+++ b/smacc_sm_reference_library/sm_atomic_performance_test/include/sm_atomic_performance_test/states/st_state_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 namespace sm_atomic_performance_test

--- a/smacc_sm_reference_library/sm_atomic_performance_test/include/sm_atomic_performance_test/states/st_state_2.h
+++ b/smacc_sm_reference_library/sm_atomic_performance_test/include/sm_atomic_performance_test/states/st_state_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 namespace sm_atomic_performance_test

--- a/smacc_sm_reference_library/sm_atomic_performance_test/package.xml
+++ b/smacc_sm_reference_library/sm_atomic_performance_test/package.xml
@@ -5,7 +5,7 @@
   <version>2.9.1</version>
   <description>The sm_atomic_performance_test package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc_sm_reference_library/sm_atomic_performance_test/src/sm_atomic_performance_test/sm_atomic_performance_test_node.cpp
+++ b/smacc_sm_reference_library/sm_atomic_performance_test/src/sm_atomic_performance_test/sm_atomic_performance_test_node.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <sm_atomic_performance_test/sm_atomic_performance_test.h>
 
 //--------------------------------------------------------------------

--- a/smacc_sm_reference_library/sm_atomic_subscribers_performance_test/include/sm_atomic_subscribers_performance_test/orthogonals/or_subscriber.h
+++ b/smacc_sm_reference_library/sm_atomic_subscribers_performance_test/include/sm_atomic_subscribers_performance_test/orthogonals/or_subscriber.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/client_bases/smacc_subscriber_client.h>
 #include <smacc/smacc.h>
 

--- a/smacc_sm_reference_library/sm_atomic_subscribers_performance_test/include/sm_atomic_subscribers_performance_test/sm_atomic_subscribers_performance_test.h
+++ b/smacc_sm_reference_library/sm_atomic_subscribers_performance_test/include/sm_atomic_subscribers_performance_test/sm_atomic_subscribers_performance_test.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 #include "orthogonals/or_subscriber.h"
 

--- a/smacc_sm_reference_library/sm_atomic_subscribers_performance_test/include/sm_atomic_subscribers_performance_test/states/st_state_1.h
+++ b/smacc_sm_reference_library/sm_atomic_subscribers_performance_test/include/sm_atomic_subscribers_performance_test/states/st_state_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 namespace sm_atomic_subscribers_performance_test

--- a/smacc_sm_reference_library/sm_atomic_subscribers_performance_test/include/sm_atomic_subscribers_performance_test/states/st_state_2.h
+++ b/smacc_sm_reference_library/sm_atomic_subscribers_performance_test/include/sm_atomic_subscribers_performance_test/states/st_state_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 namespace sm_atomic_subscribers_performance_test

--- a/smacc_sm_reference_library/sm_atomic_subscribers_performance_test/package.xml
+++ b/smacc_sm_reference_library/sm_atomic_subscribers_performance_test/package.xml
@@ -5,7 +5,7 @@
   <version>2.9.1</version>
   <description>The sm_atomic_subscribers_performance_test package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc_sm_reference_library/sm_atomic_subscribers_performance_test/servers/basic_publisher.py
+++ b/smacc_sm_reference_library/sm_atomic_subscribers_performance_test/servers/basic_publisher.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+
+# Copyright 2021 RobosoftAI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import rclpy
 from rclpy.node import Node
 from std_msgs.msg import Int16

--- a/smacc_sm_reference_library/sm_atomic_subscribers_performance_test/src/sm_atomic_subscribers_performance_test/sm_atomic_subscribers_performance_test_node.cpp
+++ b/smacc_sm_reference_library/sm_atomic_subscribers_performance_test/src/sm_atomic_subscribers_performance_test/sm_atomic_subscribers_performance_test_node.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <sm_atomic_subscribers_performance_test/sm_atomic_subscribers_performance_test.h>
 
 //--------------------------------------------------------------------

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_led/cl_led.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_led/cl_led.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <smacc/client_bases/smacc_action_client_base.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_led/client_behaviors/cb_led_off.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_led/client_behaviors/cb_led_off.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <sm_dance_bot/clients/cl_led/cl_led.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_led/client_behaviors/cb_led_on.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_led/client_behaviors/cb_led_on.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <sm_dance_bot/clients/cl_led/cl_led.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_lidar/cl_lidar.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_lidar/cl_lidar.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <multirole_sensor_client/cl_multirole_sensor.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_lidar/client_behaviors/cb_lidar_sensor.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_lidar/client_behaviors/cb_lidar_sensor.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <multirole_sensor_client/client_behaviors/cb_default_multirole_sensor_behavior.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_service3/cl_service3.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_service3/cl_service3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <smacc/client_bases/smacc_service_client.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_service3/client_behaviors/cb_service3.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_service3/client_behaviors/cb_service3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <sm_dance_bot/clients/cl_service3/cl_service3.h>
 #include <smacc/smacc_client_behavior.h>
 

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_string_publisher/cl_string_publisher.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_string_publisher/cl_string_publisher.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <smacc/client_bases/smacc_publisher_client.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_string_publisher/client_behaviors/cb_string_publisher.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_string_publisher/client_behaviors/cb_string_publisher.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <sm_dance_bot/clients/cl_string_publisher/cl_string_publisher.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_temperature_sensor/cl_temperature_sensor.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_temperature_sensor/cl_temperature_sensor.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <multirole_sensor_client/cl_multirole_sensor.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_temperature_sensor/client_behaviors/cb_custom_condition_temperature_sensor.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/clients/cl_temperature_sensor/client_behaviors/cb_custom_condition_temperature_sensor.h
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 #include <multirole_sensor_client/client_behaviors/cb_default_multirole_sensor_behavior.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/modestates/ms_dance_bot_recovery_mode.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/modestates/ms_dance_bot_recovery_mode.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot
 {

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/modestates/ms_dance_bot_run_mode.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/modestates/ms_dance_bot_run_mode.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot
 {

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/orthogonals/or_led.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/orthogonals/or_led.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 #include <sm_dance_bot/clients/cl_led/cl_led.h>
 #include <smacc/smacc_orthogonal.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/orthogonals/or_navigation.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/orthogonals/or_navigation.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <move_base_z_client_plugin/move_base_z_client_plugin.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/orthogonals/or_obstacle_perception.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/orthogonals/or_obstacle_perception.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <sm_dance_bot/clients/cl_lidar/cl_lidar.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/orthogonals/or_service3.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/orthogonals/or_service3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <sm_dance_bot/clients/cl_service3/cl_service3.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/orthogonals/or_string_publisher.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/orthogonals/or_string_publisher.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <sm_dance_bot/clients/cl_string_publisher/cl_string_publisher.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/orthogonals/or_temperature_sensor.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/orthogonals/or_temperature_sensor.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <multirole_sensor_client/cl_multirole_sensor.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/orthogonals/or_timer.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/orthogonals/or_timer.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 #include <ros_timer_client/cl_ros_timer.h>
 #include <smacc/smacc_orthogonal.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/orthogonals/or_updatable_publisher.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/orthogonals/or_updatable_publisher.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <ros_publisher_client/cl_ros_publisher.h>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/sm_dance_bot.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/sm_dance_bot.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 #include <sensor_msgs/msg/laser_scan.hpp>

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/f_pattern_states/sti_fpattern_forward_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/f_pattern_states/sti_fpattern_forward_1.h
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace sm_dance_bot
 {

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/f_pattern_states/sti_fpattern_forward_2.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/f_pattern_states/sti_fpattern_forward_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace f_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/f_pattern_states/sti_fpattern_loop_start.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/f_pattern_states/sti_fpattern_loop_start.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace f_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/f_pattern_states/sti_fpattern_return_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/f_pattern_states/sti_fpattern_return_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace f_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/f_pattern_states/sti_fpattern_rotate_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/f_pattern_states/sti_fpattern_rotate_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace f_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/f_pattern_states/sti_fpattern_rotate_2.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/f_pattern_states/sti_fpattern_rotate_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace f_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/radial_motion_states/sti_radial_end_point.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/radial_motion_states/sti_radial_end_point.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace radial_motion_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/radial_motion_states/sti_radial_loop_start.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/radial_motion_states/sti_radial_loop_start.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace radial_motion_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/radial_motion_states/sti_radial_return.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/radial_motion_states/sti_radial_return.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace radial_motion_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/radial_motion_states/sti_radial_rotate.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/radial_motion_states/sti_radial_rotate.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace radial_motion_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_forward_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_forward_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_forward_2.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_forward_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_forward_3.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_forward_3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_forward_4.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_forward_4.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_loop_start.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_loop_start.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_rotate_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_rotate_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_rotate_2.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_rotate_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_rotate_3.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_rotate_3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_rotate_4.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/s_pattern_states/sti_spattern_rotate_4.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_acquire_sensors.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_acquire_sensors.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot
 {

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_event_count_down.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_event_count_down.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot
 {

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_navigate_forward_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_navigate_forward_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <move_base_z_client_plugin/move_base_z_client_plugin.h>
 #include <smacc/smacc.h>
 

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_navigate_forward_2.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_navigate_forward_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot
 {

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_navigate_reverse_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_navigate_reverse_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot
 {

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_navigate_reverse_2.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_navigate_reverse_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot
 {

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_navigate_reverse_3.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_navigate_reverse_3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot
 {

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_navigate_to_waypoint_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_navigate_to_waypoint_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot
 {

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_navigate_to_waypoints_x.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_navigate_to_waypoints_x.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot
 {

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_rotate_degrees_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_rotate_degrees_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot
 {

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_rotate_degrees_2.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_rotate_degrees_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot
 {

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_rotate_degrees_3.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_rotate_degrees_3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot
 {

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_rotate_degrees_4.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_rotate_degrees_4.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot
 {

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_rotate_degrees_5.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_rotate_degrees_5.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot
 {

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_rotate_degrees_6.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/states/st_rotate_degrees_6.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot
 {

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/superstates/ss_f_pattern_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/superstates/ss_f_pattern_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 namespace sm_dance_bot

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/superstates/ss_radial_pattern_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/superstates/ss_radial_pattern_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 namespace sm_dance_bot

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/superstates/ss_radial_pattern_2.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/superstates/ss_radial_pattern_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 namespace sm_dance_bot

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/superstates/ss_radial_pattern_3.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/superstates/ss_radial_pattern_3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 namespace sm_dance_bot

--- a/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/superstates/ss_s_pattern_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot/include/sm_dance_bot/superstates/ss_s_pattern_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 namespace sm_dance_bot

--- a/smacc_sm_reference_library/sm_dance_bot/launch/gazebo_launch.py
+++ b/smacc_sm_reference_library/sm_dance_bot/launch/gazebo_launch.py
@@ -1,3 +1,17 @@
+# Copyright 2021 RobosoftAI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
 from ament_index_python.packages import get_package_share_directory

--- a/smacc_sm_reference_library/sm_dance_bot/launch/online_sync_launch.py
+++ b/smacc_sm_reference_library/sm_dance_bot/launch/online_sync_launch.py
@@ -1,3 +1,17 @@
+# Copyright 2021 RobosoftAI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration

--- a/smacc_sm_reference_library/sm_dance_bot/package.xml
+++ b/smacc_sm_reference_library/sm_dance_bot/package.xml
@@ -5,7 +5,7 @@
   <version>2.9.1</version>
   <description>The dance_bot package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc_sm_reference_library/sm_dance_bot/servers/led_action_server/src/led_action_server_node.cpp
+++ b/smacc_sm_reference_library/sm_dance_bot/servers/led_action_server/src/led_action_server_node.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_sm_reference_library/sm_dance_bot/servers/service_node_3/service_node_3.py
+++ b/smacc_sm_reference_library/sm_dance_bot/servers/service_node_3/service_node_3.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python3
 
+# Copyright 2021 RobosoftAI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # import roslib
 # import rospy

--- a/smacc_sm_reference_library/sm_dance_bot/servers/temperature_sensor_node/src/temperature_sensor_node.cpp
+++ b/smacc_sm_reference_library/sm_dance_bot/servers/temperature_sensor_node/src/temperature_sensor_node.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/temperature.hpp>
 

--- a/smacc_sm_reference_library/sm_dance_bot/src/sm_dance_bot/clients/cl_led/cl_led.cpp
+++ b/smacc_sm_reference_library/sm_dance_bot/src/sm_dance_bot/clients/cl_led/cl_led.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_sm_reference_library/sm_dance_bot/src/sm_dance_bot/sm_dance_bot.cpp
+++ b/smacc_sm_reference_library/sm_dance_bot/src/sm_dance_bot/sm_dance_bot.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <sm_dance_bot/sm_dance_bot.h>
 
 int main(int argc, char ** argv)

--- a/smacc_sm_reference_library/sm_dance_bot_msgs/package.xml
+++ b/smacc_sm_reference_library/sm_dance_bot_msgs/package.xml
@@ -5,7 +5,7 @@
   <version>2.9.1</version>
   <description>The dance_bot package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_led/cl_led.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_led/cl_led.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <smacc/client_bases/smacc_action_client_base.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_led/client_behaviors/cb_led_off.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_led/client_behaviors/cb_led_off.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <sm_dance_bot_strikes_back/clients/cl_led/cl_led.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_led/client_behaviors/cb_led_on.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_led/client_behaviors/cb_led_on.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <sm_dance_bot_strikes_back/clients/cl_led/cl_led.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_lidar/cl_lidar.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_lidar/cl_lidar.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <multirole_sensor_client/cl_multirole_sensor.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_lidar/client_behaviors/cb_lidar_sensor.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_lidar/client_behaviors/cb_lidar_sensor.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <multirole_sensor_client/client_behaviors/cb_default_multirole_sensor_behavior.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_lidar/components/cp_lidar_data.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_lidar/components/cp_lidar_data.h
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <smacc/smacc.h>
 

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_service3/cl_service3.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_service3/cl_service3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <smacc/client_bases/smacc_service_client.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_service3/client_behaviors/cb_service3.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_service3/client_behaviors/cb_service3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <sm_dance_bot_strikes_back/clients/cl_service3/cl_service3.h>
 #include <smacc/smacc_client_behavior.h>
 

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_string_publisher/cl_string_publisher.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_string_publisher/cl_string_publisher.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <smacc/client_bases/smacc_publisher_client.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_string_publisher/client_behaviors/cb_string_publisher.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_string_publisher/client_behaviors/cb_string_publisher.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <sm_dance_bot_strikes_back/clients/cl_string_publisher/cl_string_publisher.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_temperature_sensor/cl_temperature_sensor.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_temperature_sensor/cl_temperature_sensor.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <multirole_sensor_client/cl_multirole_sensor.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_temperature_sensor/client_behaviors/cb_custom_condition_temperature_sensor.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/clients/cl_temperature_sensor/client_behaviors/cb_custom_condition_temperature_sensor.h
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 #include <multirole_sensor_client/client_behaviors/cb_default_multirole_sensor_behavior.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/modestates/ms_dance_bot_recovery_mode.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/modestates/ms_dance_bot_recovery_mode.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot_strikes_back
 {

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/modestates/ms_dance_bot_run_mode.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/modestates/ms_dance_bot_run_mode.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot_strikes_back
 {

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/orthogonals/or_led.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/orthogonals/or_led.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 #include <sm_dance_bot_strikes_back/clients/cl_led/cl_led.h>
 #include <smacc/smacc_orthogonal.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/orthogonals/or_navigation.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/orthogonals/or_navigation.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <move_base_z_client_plugin/move_base_z_client_plugin.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/orthogonals/or_obstacle_perception.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/orthogonals/or_obstacle_perception.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <sm_dance_bot_strikes_back/clients/cl_lidar/cl_lidar.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/orthogonals/or_service3.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/orthogonals/or_service3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <sm_dance_bot_strikes_back/clients/cl_service3/cl_service3.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/orthogonals/or_string_publisher.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/orthogonals/or_string_publisher.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <sm_dance_bot_strikes_back/clients/cl_string_publisher/cl_string_publisher.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/orthogonals/or_temperature_sensor.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/orthogonals/or_temperature_sensor.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <multirole_sensor_client/cl_multirole_sensor.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/orthogonals/or_timer.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/orthogonals/or_timer.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 #include <ros_timer_client/cl_ros_timer.h>
 #include <smacc/smacc_orthogonal.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/orthogonals/or_updatable_publisher.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/orthogonals/or_updatable_publisher.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <ros_publisher_client/cl_ros_publisher.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/sm_dance_bot_strikes_back.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/sm_dance_bot_strikes_back.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 #include <sensor_msgs/msg/laser_scan.hpp>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/f_pattern_states/sti_fpattern_forward_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/f_pattern_states/sti_fpattern_forward_1.h
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace sm_dance_bot_strikes_back
 {

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/f_pattern_states/sti_fpattern_forward_2.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/f_pattern_states/sti_fpattern_forward_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot_strikes_back
 {
 namespace f_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/f_pattern_states/sti_fpattern_loop_start.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/f_pattern_states/sti_fpattern_loop_start.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot_strikes_back
 {
 namespace f_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/f_pattern_states/sti_fpattern_return_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/f_pattern_states/sti_fpattern_return_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot_strikes_back
 {
 namespace f_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/f_pattern_states/sti_fpattern_rotate_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/f_pattern_states/sti_fpattern_rotate_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot_strikes_back
 {
 namespace f_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/f_pattern_states/sti_fpattern_rotate_2.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/f_pattern_states/sti_fpattern_rotate_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <angles/angles.h>
 namespace sm_dance_bot_strikes_back
 {

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/radial_motion_states/sti_radial_end_point.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/radial_motion_states/sti_radial_end_point.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot_strikes_back
 {
 namespace radial_motion_states

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/radial_motion_states/sti_radial_loop_start.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/radial_motion_states/sti_radial_loop_start.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot_strikes_back
 {
 namespace radial_motion_states

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/radial_motion_states/sti_radial_return.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/radial_motion_states/sti_radial_return.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot_strikes_back
 {
 namespace radial_motion_states

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/radial_motion_states/sti_radial_rotate.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/radial_motion_states/sti_radial_rotate.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot_strikes_back
 {
 namespace radial_motion_states

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_forward_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_forward_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot_strikes_back
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_forward_2.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_forward_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot_strikes_back
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_forward_3.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_forward_3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot_strikes_back
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_forward_4.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_forward_4.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot_strikes_back
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_loop_start.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_loop_start.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot_strikes_back
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_rotate_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_rotate_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot_strikes_back
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_rotate_2.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_rotate_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot_strikes_back
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_rotate_3.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_rotate_3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot_strikes_back
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_rotate_4.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/s_pattern_states/sti_spattern_rotate_4.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_dance_bot_strikes_back
 {
 namespace s_pattern_states

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/st_acquire_sensors.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/st_acquire_sensors.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot_strikes_back
 {

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/st_event_count_down.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/st_event_count_down.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot_strikes_back
 {

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/st_fpattern_prealignment.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/st_fpattern_prealignment.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot_strikes_back
 {

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/st_navigate_to_waypoints_x.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/st_navigate_to_waypoints_x.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot_strikes_back
 {

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/st_spattern_prealignment.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/states/st_spattern_prealignment.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_dance_bot_strikes_back
 {

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/superstates/ss_f_pattern_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/superstates/ss_f_pattern_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <angles/angles.h>
 #include <smacc/smacc.h>
 #include <tf2/transform_datatypes.h>

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/superstates/ss_radial_pattern_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/superstates/ss_radial_pattern_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 namespace sm_dance_bot_strikes_back

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/superstates/ss_radial_pattern_2.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/superstates/ss_radial_pattern_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 namespace sm_dance_bot_strikes_back

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/superstates/ss_radial_pattern_3.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/superstates/ss_radial_pattern_3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 namespace sm_dance_bot_strikes_back

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/superstates/ss_s_pattern_1.h
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/include/sm_dance_bot_strikes_back/superstates/ss_s_pattern_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 
 namespace sm_dance_bot_strikes_back

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/launch/gazebo_launch.py
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/launch/gazebo_launch.py
@@ -1,3 +1,17 @@
+# Copyright 2021 RobosoftAI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
 from ament_index_python.packages import get_package_share_directory

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/launch/online_sync_launch.py
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/launch/online_sync_launch.py
@@ -1,3 +1,17 @@
+# Copyright 2021 RobosoftAI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/package.xml
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/package.xml
@@ -6,7 +6,7 @@
 
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
 
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/servers/led_action_server/src/led_action_server_node.cpp
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/servers/led_action_server/src/led_action_server_node.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/servers/service_node_3/service_node_3.py
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/servers/service_node_3/service_node_3.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python3
 
+# Copyright 2021 RobosoftAI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # import roslib
 # import rospy

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/servers/temperature_sensor_node/src/temperature_sensor_node.cpp
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/servers/temperature_sensor_node/src/temperature_sensor_node.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/temperature.hpp>
 

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/src/sm_dance_bot_strikes_back/clients/cl_led/cl_led.cpp
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/src/sm_dance_bot_strikes_back/clients/cl_led/cl_led.cpp
@@ -1,5 +1,19 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*****************************************************************************************************************
- * ReelRobotix Inc. - Software License Agreement      Copyright (c) 2018
+ *
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/src/sm_dance_bot_strikes_back/clients/cl_lidar/cp_lidar_data.cpp
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/src/sm_dance_bot_strikes_back/clients/cl_lidar/cp_lidar_data.cpp
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <smacc/smacc.h>
 

--- a/smacc_sm_reference_library/sm_dance_bot_strikes_back/src/sm_dance_bot_strikes_back/sm_dance_bot_strikes_back.cpp
+++ b/smacc_sm_reference_library/sm_dance_bot_strikes_back/src/sm_dance_bot_strikes_back/sm_dance_bot_strikes_back.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <sm_dance_bot_strikes_back/sm_dance_bot_strikes_back.h>
 int main(int argc, char ** argv)
 {

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/clients/cl_subscriber/cl_subscriber.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/clients/cl_subscriber/cl_subscriber.h
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 #include <smacc/client_bases/smacc_subscriber_client.h>

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/clients/cl_subscriber/client_behaviors/cb_my_subscriber_behavior.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/clients/cl_subscriber/client_behaviors/cb_my_subscriber_behavior.h
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 #include <sm_ferrari/clients/cl_subscriber/cl_subscriber.h>

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/mode_states/ms_recover.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/mode_states/ms_recover.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_ferrari
 {

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/mode_states/ms_run.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/mode_states/ms_run.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_ferrari
 {

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/orthogonals/or_keyboard.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/orthogonals/or_keyboard.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <keyboard_client/cl_keyboard.h>

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/orthogonals/or_subscriber.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/orthogonals/or_subscriber.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <sm_ferrari/clients/cl_subscriber/cl_subscriber.h>

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/orthogonals/or_timer.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/orthogonals/or_timer.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <ros_timer_client/cl_ros_timer.h>

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/orthogonals/or_updatable_publisher.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/orthogonals/or_updatable_publisher.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <ros_publisher_client/cl_ros_publisher.h>

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/sm_ferrari.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/sm_ferrari.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <smacc/smacc.h>

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/states/inner_states/sti_state_1.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/states/inner_states/sti_state_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_ferrari
 {
 namespace inner_states

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/states/inner_states/sti_state_2.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/states/inner_states/sti_state_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_ferrari
 {
 namespace inner_states

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/states/inner_states/sti_state_3.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/states/inner_states/sti_state_3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_ferrari
 {
 namespace inner_states

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/states/st_state_1.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/states/st_state_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_ferrari
 {
 // STATE DECLARATION

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/states/st_state_2.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/states/st_state_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_ferrari
 {
 using namespace std::chrono_literals;

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/states/st_state_3.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/states/st_state_3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_ferrari
 {
 // STATE DECLARATION

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/states/st_state_4.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/states/st_state_4.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_ferrari
 {
 // STATE DECLARATION

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/superstates/ss_superstate_1.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/superstates/ss_superstate_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_ferrari
 {
 namespace SS1

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/superstates/ss_superstate_2.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/superstates/ss_superstate_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_ferrari
 {
 namespace SS2

--- a/smacc_sm_reference_library/sm_ferrari/package.xml
+++ b/smacc_sm_reference_library/sm_ferrari/package.xml
@@ -5,7 +5,7 @@
   <version>0.9.1</version>
   <description>The sm_ferrari package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Iñigo Blasco</maintainer>
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc_sm_reference_library/sm_ferrari/servers/temperature_sensor_node/src/temperature_sensor_node.cpp
+++ b/smacc_sm_reference_library/sm_ferrari/servers/temperature_sensor_node/src/temperature_sensor_node.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/float32.hpp>
 

--- a/smacc_sm_reference_library/sm_ferrari/src/sm_ferrari_node.cpp
+++ b/smacc_sm_reference_library/sm_ferrari/src/sm_ferrari_node.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <sm_ferrari/sm_ferrari.h>
 
 int main(int argc, char ** argv)

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/clients/cl_subscriber/cl_subscriber.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/clients/cl_subscriber/cl_subscriber.h
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 #include <smacc/client_bases/smacc_subscriber_client.h>

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/clients/cl_subscriber/client_behaviors/cb_default_subscriber_behavior.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/clients/cl_subscriber/client_behaviors/cb_default_subscriber_behavior.h
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 #include <sm_three_some/clients/cl_subscriber/cl_subscriber.h>

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/clients/cl_subscriber/client_behaviors/cb_watchdog_subscriber_behavior.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/clients/cl_subscriber/client_behaviors/cb_watchdog_subscriber_behavior.h
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 #include <sm_three_some/clients/cl_subscriber/cl_subscriber.h>

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/mode_states/ms_recover.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/mode_states/ms_recover.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_three_some
 {

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/mode_states/ms_run.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/mode_states/ms_run.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <smacc/smacc.h>
 namespace sm_three_some
 {

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/orthogonals/or_keyboard.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/orthogonals/or_keyboard.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <keyboard_client/cl_keyboard.h>

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/orthogonals/or_subscriber.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/orthogonals/or_subscriber.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <sm_three_some/clients/cl_subscriber/cl_subscriber.h>

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/orthogonals/or_timer.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/orthogonals/or_timer.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <ros_timer_client/cl_ros_timer.h>

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/orthogonals/or_updatable_publisher.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/orthogonals/or_updatable_publisher.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <ros_publisher_client/cl_ros_publisher.h>

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/sm_three_some.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/sm_three_some.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <smacc/smacc.h>

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/states/inner_states/sti_state_1.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/states/inner_states/sti_state_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_three_some
 {
 namespace inner_states

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/states/inner_states/sti_state_2.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/states/inner_states/sti_state_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_three_some
 {
 namespace inner_states

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/states/inner_states/sti_state_3.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/states/inner_states/sti_state_3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_three_some
 {
 namespace inner_states

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/states/st_state_1.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/states/st_state_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_three_some
 {
 // STATE DECLARATION

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/states/st_state_2.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/states/st_state_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_three_some
 {
 // STATE DECLARATION

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/states/st_state_3.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/states/st_state_3.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_three_some
 {
 // STATE DECLARATION

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/states/st_state_4.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/states/st_state_4.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_three_some
 {
 // STATE DECLARATION

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/superstates/ss_superstate_1.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/superstates/ss_superstate_1.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_three_some
 {
 namespace SS1

--- a/smacc_sm_reference_library/sm_three_some/include/sm_three_some/superstates/ss_superstate_2.h
+++ b/smacc_sm_reference_library/sm_three_some/include/sm_three_some/superstates/ss_superstate_2.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace sm_three_some
 {
 namespace SS2

--- a/smacc_sm_reference_library/sm_three_some/package.xml
+++ b/smacc_sm_reference_library/sm_three_some/package.xml
@@ -5,7 +5,7 @@
   <version>0.9.1</version>
   <description>The sm_three_some package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Iñigo Blasco</maintainer>
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc_sm_reference_library/sm_three_some/src/sm_three_some_node.cpp
+++ b/smacc_sm_reference_library/sm_three_some/src/sm_three_some_node.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <sm_three_some/sm_three_some.h>
 
 int main(int argc, char ** argv)

--- a/smacc_state_reactor_library/sr_all_events_go/include/sr_all_events_go/sr_all_events_go.h
+++ b/smacc_state_reactor_library/sr_all_events_go/include/sr_all_events_go/sr_all_events_go.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 #include <smacc/common.h>
 #include <smacc/smacc_state_reactor.h>

--- a/smacc_state_reactor_library/sr_all_events_go/package.xml
+++ b/smacc_state_reactor_library/sr_all_events_go/package.xml
@@ -5,7 +5,7 @@
   <version>2.9.1</version>
   <description>The sr_all_events_go package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Iñigo Blasco</maintainer>
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc_state_reactor_library/sr_all_events_go/src/sr_all_events_go/sr_all_events_go.cpp
+++ b/smacc_state_reactor_library/sr_all_events_go/src/sr_all_events_go/sr_all_events_go.cpp
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <smacc/common.h>
 #include <sr_all_events_go/sr_all_events_go.h>

--- a/smacc_state_reactor_library/sr_conditional/include/sr_conditional/sr_conditional.h
+++ b/smacc_state_reactor_library/sr_conditional/include/sr_conditional/sr_conditional.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 #include <smacc/common.h>
 #include <smacc/smacc_state_reactor.h>

--- a/smacc_state_reactor_library/sr_conditional/package.xml
+++ b/smacc_state_reactor_library/sr_conditional/package.xml
@@ -5,7 +5,7 @@
   <version>2.9.1</version>
   <description>The sr_conditional package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc_state_reactor_library/sr_conditional/src/sr_conditional/sr_conditional.cpp
+++ b/smacc_state_reactor_library/sr_conditional/src/sr_conditional/sr_conditional.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <sr_conditional/sr_conditional.h>
 
 namespace smacc

--- a/smacc_state_reactor_library/sr_event_countdown/include/sr_event_countdown/sr_event_countdown.h
+++ b/smacc_state_reactor_library/sr_event_countdown/include/sr_event_countdown/sr_event_countdown.h
@@ -1,3 +1,17 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 #include <smacc/common.h>
 #include <smacc/smacc_state_reactor.h>

--- a/smacc_state_reactor_library/sr_event_countdown/package.xml
+++ b/smacc_state_reactor_library/sr_event_countdown/package.xml
@@ -5,7 +5,7 @@
   <version>2.9.1</version>
   <description>The sr_event_countdown package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
-  <license>BSD-3</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/smacc_state_reactor_library/sr_event_countdown/src/sr_event_countdown/sr_event_countdown.cpp
+++ b/smacc_state_reactor_library/sr_event_countdown/src/sr_event_countdown/sr_event_countdown.cpp
@@ -1,3 +1,16 @@
+// Copyright 2021 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <smacc/common.h>
 #include <sr_event_countdown/sr_event_countdown.h>


### PR DESCRIPTION
- Change license into package.xml
- Add Apache2.0 license header and remove the old one.

`ament_copyright` is passing - that was the goal of the PR. So please merge if happy with the license.
