### PR TITLE
[Fix] Fix boost bind warnings

### DIFF
--- a/smacc2/include/smacc2/common.hpp
+++ b/smacc2/include/smacc2/common.hpp
@@ -19,6 +19,8 @@
  ******************************************************************************************************************/
 #pragma once
 
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
+
 // boost statechart
 #include <boost/statechart/asynchronous_state_machine.hpp>
 #include <boost/statechart/custom_reaction.hpp>


### PR DESCRIPTION
1. add definition BOOST_BIND_NO_PLACEHOLDERS to avoid boost bind
   warnings

Signed-off-by: Homalozoa <nx.tardis@gmail.com>