### PR TITLE
Add QOS durability to SmaccPublisherClient

### DIFF
--- a/smacc2/include/smacc2/client_bases/smacc_publisher_client.hpp
+++ b/smacc2/include/smacc2/client_bases/smacc_publisher_client.hpp
@@ -56,7 +56,6 @@ public:
       qos.keep_last(*queueSize);
       qos.durability(*durability);
 
-
       RCLCPP_INFO_STREAM(
         getNode()->get_logger(),
         "[" << this->getName() << "] Client Publisher to topic: " << topicName);

--- a/smacc2/include/smacc2/client_bases/smacc_publisher_client.hpp
+++ b/smacc2/include/smacc2/client_bases/smacc_publisher_client.hpp
@@ -54,7 +54,7 @@ public:
       if (!durability) durability = RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT;
       rclcpp::SensorDataQoS qos;
       qos.keep_last(*queueSize);
-      qos.durability(*durability)
+      qos.durability(*durability);
 
 
       RCLCPP_INFO_STREAM(

--- a/smacc2/include/smacc2/client_bases/smacc_publisher_client.hpp
+++ b/smacc2/include/smacc2/client_bases/smacc_publisher_client.hpp
@@ -33,6 +33,7 @@ public:
   std::optional<std::string> topicName;
   std::optional<int> queueSize;
   std::optional<rmw_qos_durability_policy_t> durability;
+  std::optional<rmw_qos_reliability_policy_t> reliability;
 
   SmaccPublisherClient();
   virtual ~SmaccPublisherClient();
@@ -52,9 +53,11 @@ public:
 
       if (!queueSize) queueSize = 1;
       if (!durability) durability = RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT;
+      if (!reliability) reliability = RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT;
       rclcpp::SensorDataQoS qos;
       qos.keep_last(*queueSize);
       qos.durability(*durability);
+      qos.reliability(*reliability);
 
       RCLCPP_INFO_STREAM(
         getNode()->get_logger(),

--- a/smacc2/include/smacc2/client_bases/smacc_publisher_client.hpp
+++ b/smacc2/include/smacc2/client_bases/smacc_publisher_client.hpp
@@ -32,6 +32,7 @@ class SmaccPublisherClient : public smacc2::ISmaccClient
 public:
   std::optional<std::string> topicName;
   std::optional<int> queueSize;
+  std::optional<rmw_qos_durability_policy_t> durability;
 
   SmaccPublisherClient();
   virtual ~SmaccPublisherClient();
@@ -50,8 +51,11 @@ public:
       }
 
       if (!queueSize) queueSize = 1;
+      if (!durability) durability = RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT;
       rclcpp::SensorDataQoS qos;
       qos.keep_last(*queueSize);
+      qos.durability(*durability)
+
 
       RCLCPP_INFO_STREAM(
         getNode()->get_logger(),


### PR DESCRIPTION
Just some small changes to add the ability to configure qos durability. 

This is particularly useful for people like me who need "RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL"