### PR TITLE
SrConditional fixes and formatting

### DIFF
--- a/smacc2_state_reactor_library/sr_conditional/include/sr_conditional/sr_conditional.hpp
+++ b/smacc2_state_reactor_library/sr_conditional/include/sr_conditional/sr_conditional.hpp
@@ -24,20 +24,19 @@ namespace smacc2
 namespace state_reactors
 {
 template <typename TSource, typename TObjectTag = EmptyObjectTag>
-struct Evsr_conditionalTrue : sc::event<Evsr_conditionalTrue<TSource, TObjectTag>>
+struct EvConditionalTrue : sc::event<EvConditionalTrue<TSource, TObjectTag>>
 {
 };
 
-//-----------------------------------------------------------------------
-class Srsr_conditional : public StateReactor
+template <typename TEv>
+class SrConditional : public StateReactor
 {
 private:
   std::map<const std::type_info *, bool> triggeredEvents;
   bool conditionFlag;
 
 public:
-  template <typename TEv>
-  Srsr_conditional(std::function<bool(TEv *)> sr_conditionalFunction)
+  SrConditional(std::function<bool(TEv *)> sr_conditionalFunction)
   {
     std::function<void(TEv *)> callback = [=](TEv * ev) {
       bool condition = sr_conditionalFunction(ev);
@@ -47,7 +46,7 @@ public:
     this->createEventCallback(callback);
   }
 
-  ~Srsr_conditional();
+  ~SrConditional();
 
   virtual bool triggers() override;
 };

--- a/smacc2_state_reactor_library/sr_conditional/include/sr_conditional/sr_conditional.hpp
+++ b/smacc2_state_reactor_library/sr_conditional/include/sr_conditional/sr_conditional.hpp
@@ -46,10 +46,7 @@ public:
     this->createEventCallback(callback);
   }
 
-  bool triggers()
-  {
-    return this->conditionFlag;
-  }
+  bool triggers() { return this->conditionFlag; }
 };
 }  // namespace state_reactors
 }  // namespace smacc2

--- a/smacc2_state_reactor_library/sr_conditional/include/sr_conditional/sr_conditional.hpp
+++ b/smacc2_state_reactor_library/sr_conditional/include/sr_conditional/sr_conditional.hpp
@@ -46,9 +46,10 @@ public:
     this->createEventCallback(callback);
   }
 
-  ~SrConditional();
-
-  virtual bool triggers() override;
+  bool triggers()
+  {
+    return this->conditionFlag;
+  }
 };
 }  // namespace state_reactors
 }  // namespace smacc2

--- a/smacc2_state_reactor_library/sr_conditional/src/sr_conditional/sr_conditional.cpp
+++ b/smacc2_state_reactor_library/sr_conditional/src/sr_conditional/sr_conditional.cpp
@@ -18,8 +18,8 @@ namespace smacc2
 {
 namespace state_reactors
 {
-Srsr_conditional::~Srsr_conditional() {}
+SrConditional::~SrConditional() {}
 
-bool Srsr_conditional::triggers() { return this->conditionFlag; }
+bool SrConditional::triggers() { return this->conditionFlag; }
 }  // namespace state_reactors
 }  // namespace smacc2

--- a/smacc2_state_reactor_library/sr_conditional/src/sr_conditional/sr_conditional.cpp
+++ b/smacc2_state_reactor_library/sr_conditional/src/sr_conditional/sr_conditional.cpp
@@ -18,8 +18,5 @@ namespace smacc2
 {
 namespace state_reactors
 {
-SrConditional::~SrConditional() {}
-
-bool SrConditional::triggers() { return this->conditionFlag; }
 }  // namespace state_reactors
 }  // namespace smacc2


### PR DESCRIPTION
* Standardises the formatting of SrConditional.
* Moves the template to the class instead of the constructor (I couldn't figure out how to make the template work when on the constructor but I am an absolute c++ novice).

Example usage:
```c++
    auto callback = [ = ](EvTopicMessage<ClSomeSubscriber, OrSomeOrthogonal> * ev){
      // Trigger EvConditionalTrue when the msg data is >0
      return ev->msgData.data > 0;
    };

    static_createStateReactor<
      SrConditional<
        EvTopicMessage<ClSomeSubscriber, OrSomeOrthogonal>
      >,
      EvConditionalTrue<ClSomeSubscriber, OrSomeOrthogonal>,
      mpl::list<
        EvTopicMessage<ClSomeSubscriber, OrSomeOrthogonal>
      >
    >(callback);
```