### PR TITLE
Fix flag initialisation in SrConditional

### DIFF
--- a/smacc2_state_reactor_library/sr_conditional/include/sr_conditional/sr_conditional.hpp
+++ b/smacc2_state_reactor_library/sr_conditional/include/sr_conditional/sr_conditional.hpp
@@ -33,7 +33,7 @@ class SrConditional : public StateReactor
 {
 private:
   std::map<const std::type_info *, bool> triggeredEvents;
-  bool conditionFlag;
+  bool conditionFlag = false;
 
 public:
   SrConditional(std::function<bool(TEv *)> sr_conditionalFunction)


### PR DESCRIPTION
Hey hey,

I was having an issue with SrConditional not triggering reliably. Turns on the `conditionFlag` was not being initialised so sometimes [triggers](https://github.com/robosoft-ai/SMACC2/blob/master/smacc2_state_reactor_library/sr_conditional/include/sr_conditional/sr_conditional.hpp#L49) would evaluate as true.

This fix defaults `conditionFlag` to false.