### PR TITLE
Fix lock_guard in smacc_state_machine_impl.hpp

### DIFF
--- a/smacc2/include/smacc2/impl/smacc_state_machine_impl.hpp
+++ b/smacc2/include/smacc2/impl/smacc_state_machine_impl.hpp
@@ -93,7 +93,7 @@ template <typename TOrthogonal>
 void ISmaccStateMachine::createOrthogonal()
 {
   //this->lockStateMachine("create orthogonal");
-  std::lock_guard<std::recursive_mutex> guard();
+  std::lock_guard<std::recursive_mutex> lock(m_mutex_);
   std::string orthogonalkey = demangledTypeName<TOrthogonal>();
 
   if (orthogonals_.count(orthogonalkey) == 0)


### PR DESCRIPTION
This fixes a lock_guard in smacc_state_machine_impl.hpp. Currently, this lock_guard is leading to compiler errors.