### PR TITLE
exception at init when passing a signal_detector_loop_freq parameter

### DIFF
--- a/smacc2/src/smacc2/signal_detector.cpp
+++ b/smacc2/src/smacc2/signal_detector.cpp
@@ -62,7 +62,9 @@ void SignalDetector::initialize(ISmaccStateMachine * stateMachine)
   smaccStateMachine_ = stateMachine;
   lastState_ = std::numeric_limits<uint64_t>::quiet_NaN();
   findUpdatableClientsAndComponents();
-  this->getNode()->declare_parameter("signal_detector_loop_freq", this->loop_rate_hz);
+  if(!this->getNode()->has_parameter("signal_detector_loop_freq")) {
+    this->getNode()->declare_parameter("signal_detector_loop_freq", this->loop_rate_hz);
+  }
 
   initialized_ = true;
 }


### PR DESCRIPTION
**issue**
My state machine was working fine on foxy. I am migrating to humble and I get an error while launching my node: I cannot define a custom signal_detector_loop_frequency.

`ros2 run bird_sm bird_sm_node --ros-args -p signal_detector_loop_freq:=100.0`
```
[INFO] [1686669908.812311630] [BirdSm]: Creating State Machine Base: /BirdSm
terminate called after throwing an instance of 'rclcpp::exceptions::ParameterAlreadyDeclaredException'
  what():  parameter 'signal_detector_loop_freq' has already been declared
[ros2run]: Aborted
```

**proposal**
I fixed that issue by testing the parameter before the declaration.
I don't know if this is a good way to do it and if this is a behavior change between foxy and humble or if I missed something.

**tests**

`ros2 run bird_sm bird_sm_node --ros-args -p signal_detector_loop_freq:=100.0`
--> Works fine with the desired frequency

`ros2 run bird_sm bird_sm_node`
--> Works with the default frequency 20Hz


`ros2 run bird_sm bird_sm_node --ros-args -p signal_detector_loop_freq:=100`
return an error but this is expected:
```
*[INFO] [1686665345.603937129] [BirdSm]: Creating State Machine Base: /BirdSm
terminate called after throwing an instance of 'rclcpp::exceptions::InvalidParameterTypeException'
  what():  parameter 'signal_detector_loop_freq' has invalid type: expected [double] got [integer]
[ros2run]: Aborted
```

┆Issue is synchronized with this [Jira Task](https://robosoft-ai.atlassian.net/browse/SMACC2-168) by [Unito](https://www.unito.io)
