### PR TITLE
Add test dependencies on Humble branch.

### DIFF
--- a/smacc2_msgs/package.xml
+++ b/smacc2_msgs/package.xml
@@ -22,6 +22,9 @@
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <member_of_group>rosidl_interface_packages</member_of_group>
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
ament_lint_auto nor ament_lint_common are not listed as dependencies for smacc2_msgs. ament_lint_auto is required due to the `find_package` call and while `ament_lint_common` is not mentioned by name, ament_lint_auto will only work if there are ament_lint packages present for it to configure.

This is causing the build failures mentioned in
https://github.com/robosoft-ai/SMACC2/issues/508#issuecomment-1591685849

There appear to be some significant differences between the `rolling` and `humble` branches so this may not be a complete or correct change.

┆Issue is synchronized with this [Jira Task](https://robosoft-ai.atlassian.net/browse/SMACC2-170) by [Unito](https://www.unito.io)
