### PR TITLE
Reverting to the baseline clang-format

### DIFF
--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install clang-format-12
+    - name: Install clang-format
       run: |
        apt update
-       apt install -y python3-pip clang-format-12 ros-humble-ament-cppcheck
+       apt install -y python3-pip clang-format ros-humble-ament-cppcheck
        git config --global --add safe.directory `pwd`
        pip install pre-commit
     - name: pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
       - id: clang-format
         name: clang-format
         description: Format files with ClangFormat.
-        entry: clang-format-12
+        entry: clang-format
         language: system
         files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|proto|vert)$
         args: ['-fallback-style=none', '-i']


### PR DESCRIPTION
Modifying the clang-format version in the Github action containter to use the default clang-format version used in Ubuntu