### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/smacc2/CMakeLists.txt
+++ b/smacc2/CMakeLists.txt
@@ -38,7 +38,7 @@ set_source_files_properties(
   COMPILE_FLAGS "-Wno-unused-parameter"
 )
 
-ament_target_dependencies(smacc2 ${dependencies})
+target_link_libraries(smacc2 PUBLIC ${dependencies})
 target_link_libraries(smacc2
   ${Boost_LIBRARIES}
   ${LTTNGUST_LIBRARIES}

--- a/smacc2_client_library/keyboard_client/CMakeLists.txt
+++ b/smacc2_client_library/keyboard_client/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME} ${smacc2_LIBRARIES} ${std_msgs_LIBRARIES})
-ament_target_dependencies(${PROJECT_NAME} smacc2 std_msgs)
+target_link_libraries(${PROJECT_NAME} PUBLIC smacc2 std_msgs)
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 

--- a/smacc2_client_library/move_group_interface_client/CMakeLists.txt
+++ b/smacc2_client_library/move_group_interface_client/CMakeLists.txt
@@ -55,8 +55,9 @@ add_library(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME} ${YAML_CPP_LIBRARIES})
 
-ament_target_dependencies(${PROJECT_NAME}
-                          ${dependencies})
+target_link_libraries(${PROJECT_NAME} PUBLIC
+                          ${dependencies}
+)
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})

--- a/smacc2_client_library/multirole_sensor_client/CMakeLists.txt
+++ b/smacc2_client_library/multirole_sensor_client/CMakeLists.txt
@@ -24,7 +24,7 @@ include_directories(include)
 add_library(${PROJECT_NAME} SHARED
             src/${PROJECT_NAME}/cl_multirole_sensor.cpp)
 
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})

--- a/smacc2_client_library/nav2z_client/custom_planners/backward_global_planner/CMakeLists.txt
+++ b/smacc2_client_library/nav2z_client/custom_planners/backward_global_planner/CMakeLists.txt
@@ -45,8 +45,9 @@ add_library(${PROJECT_NAME} SHARED
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 pluginlib_export_plugin_description_file(nav2_core bgp_plugin.xml)
 
-ament_target_dependencies(${PROJECT_NAME}
-  ${dependencies})
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${dependencies}
+)
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})

--- a/smacc2_client_library/nav2z_client/custom_planners/backward_local_planner/CMakeLists.txt
+++ b/smacc2_client_library/nav2z_client/custom_planners/backward_local_planner/CMakeLists.txt
@@ -43,8 +43,9 @@ add_library(${PROJECT_NAME} SHARED
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 pluginlib_export_plugin_description_file(nav2_core blp_plugin.xml)
 
-ament_target_dependencies(${PROJECT_NAME}
-  ${dependencies})
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${dependencies}
+)
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})

--- a/smacc2_client_library/nav2z_client/custom_planners/forward_global_planner/CMakeLists.txt
+++ b/smacc2_client_library/nav2z_client/custom_planners/forward_global_planner/CMakeLists.txt
@@ -42,8 +42,9 @@ add_library(${PROJECT_NAME} SHARED
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 pluginlib_export_plugin_description_file(nav2_core fgp_plugin.xml)
 
-ament_target_dependencies(${PROJECT_NAME}
-  ${dependencies})
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${dependencies}
+)
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})

--- a/smacc2_client_library/nav2z_client/custom_planners/forward_local_planner/CMakeLists.txt
+++ b/smacc2_client_library/nav2z_client/custom_planners/forward_local_planner/CMakeLists.txt
@@ -42,8 +42,9 @@ add_library(${PROJECT_NAME} SHARED
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 pluginlib_export_plugin_description_file(nav2_core flp_plugin.xml)
 
-ament_target_dependencies(${PROJECT_NAME}
-  ${dependencies})
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${dependencies}
+)
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})

--- a/smacc2_client_library/nav2z_client/custom_planners/nav2z_planners_common/CMakeLists.txt
+++ b/smacc2_client_library/nav2z_client/custom_planners/nav2z_planners_common/CMakeLists.txt
@@ -36,7 +36,7 @@ include_directories(include)
 add_library(${PROJECT_NAME} SHARED
             src/${PROJECT_NAME}/common.cpp)
 
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
 target_include_directories(${PROJECT_NAME} PRIVATE include)
 
 ament_export_include_directories(include)

--- a/smacc2_client_library/nav2z_client/custom_planners/pure_spinning_local_planner/CMakeLists.txt
+++ b/smacc2_client_library/nav2z_client/custom_planners/pure_spinning_local_planner/CMakeLists.txt
@@ -44,7 +44,7 @@ add_library(${PROJECT_NAME} SHARED
 # prevent pluginlib from using boost
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 pluginlib_export_plugin_description_file(nav2_core pslp_plugin.xml)
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})

--- a/smacc2_client_library/nav2z_client/custom_planners/undo_path_global_planner/CMakeLists.txt
+++ b/smacc2_client_library/nav2z_client/custom_planners/undo_path_global_planner/CMakeLists.txt
@@ -45,8 +45,9 @@ add_library(${PROJECT_NAME} SHARED
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 pluginlib_export_plugin_description_file(nav2_core upgp_plugin.xml)
 
-ament_target_dependencies(${PROJECT_NAME}
-  ${dependencies})
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${dependencies}
+)
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})

--- a/smacc2_client_library/nav2z_client/nav2z_client/CMakeLists.txt
+++ b/smacc2_client_library/nav2z_client/nav2z_client/CMakeLists.txt
@@ -79,8 +79,9 @@ add_library(${PROJECT_NAME} SHARED
   src/${PROJECT_NAME}/components/slam_toolbox/cp_slam_toolbox.cpp
 )
 
-ament_target_dependencies(${PROJECT_NAME}
-                          ${dependencies})
+target_link_libraries(${PROJECT_NAME} PUBLIC
+                          ${dependencies}
+)
 
 target_link_libraries(${PROJECT_NAME})
 

--- a/smacc2_client_library/ros_publisher_client/CMakeLists.txt
+++ b/smacc2_client_library/ros_publisher_client/CMakeLists.txt
@@ -26,7 +26,7 @@ add_library(${PROJECT_NAME} SHARED
 )
 
 target_link_libraries(${PROJECT_NAME} ${smacc2_LIBRARIES})
-ament_target_dependencies(${PROJECT_NAME} smacc2)
+target_link_libraries(${PROJECT_NAME} PUBLIC smacc2)
 
 ament_export_dependencies(smacc2)
 ament_export_include_directories(include)

--- a/smacc2_client_library/ros_timer_client/CMakeLists.txt
+++ b/smacc2_client_library/ros_timer_client/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(${PROJECT_NAME}
   src/${PROJECT_NAME}/cb_timer_countdown_once.cpp
 )
 target_link_libraries(${PROJECT_NAME} SHARED ${Boost_LIBRARIES} smacc2)
-ament_target_dependencies(${PROJECT_NAME} smacc2)
+target_link_libraries(${PROJECT_NAME} PUBLIC smacc2)
 
 ament_export_include_directories(include)
 ament_export_dependencies(smacc2 Boost)

--- a/smacc2_event_generator_library/eg_conditional_generator/CMakeLists.txt
+++ b/smacc2_event_generator_library/eg_conditional_generator/CMakeLists.txt
@@ -21,7 +21,7 @@ include_directories(include)
 add_library(${PROJECT_NAME} SHARED
             src/eg_conditional_generator/eg_conditional_generator.cpp)
 
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})

--- a/smacc2_performance_tools/performance_tests/sm_atomic_performance_trace_1/CMakeLists.txt
+++ b/smacc2_performance_tools/performance_tests/sm_atomic_performance_trace_1/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(${PROJECT_NAME}_node
   ${Boost_LIBRARIES}
 )
 
-ament_target_dependencies(${PROJECT_NAME}_node smacc2)
+target_link_libraries(${PROJECT_NAME}_node PUBLIC smacc2)
 
 install(
   DIRECTORY include/

--- a/smacc2_performance_tools/performance_tests/sm_atomic_subscribers_performance_test/CMakeLists.txt
+++ b/smacc2_performance_tools/performance_tests/sm_atomic_subscribers_performance_test/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(${PROJECT_NAME}_node
   ${Boost_LIBRARIES}
 )
 
-ament_target_dependencies(${PROJECT_NAME}_node smacc2)
+target_link_libraries(${PROJECT_NAME}_node PUBLIC smacc2)
 
 install(
   DIRECTORY include/

--- a/smacc2_performance_tools/performance_tests/sm_coretest_transition_speed_1/CMakeLists.txt
+++ b/smacc2_performance_tools/performance_tests/sm_coretest_transition_speed_1/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(${PROJECT_NAME}_node
   ${Boost_LIBRARIES}
 )
 
-ament_target_dependencies(${PROJECT_NAME}_node smacc2)
+target_link_libraries(${PROJECT_NAME}_node PUBLIC smacc2)
 
 install(
   DIRECTORY include/

--- a/smacc2_sm_reference_library/sm_advanced_recovery_1/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_advanced_recovery_1/CMakeLists.txt
@@ -45,7 +45,7 @@ include_directories(include
 
 add_executable(${PROJECT_NAME}_node src/sm_advanced_recovery_1_node.cpp)
 
-ament_target_dependencies(${PROJECT_NAME}_node ${dependencies})
+target_link_libraries(${PROJECT_NAME}_node PUBLIC ${dependencies})
 ament_export_include_directories(include)
 
 target_link_libraries(${PROJECT_NAME}_node

--- a/smacc2_sm_reference_library/sm_atomic/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_atomic/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries(${PROJECT_NAME}_node
   ${Boost_LIBRARIES}
 )
 
-ament_target_dependencies(${PROJECT_NAME}_node smacc2)
+target_link_libraries(${PROJECT_NAME}_node PUBLIC smacc2)
 
 install(
   DIRECTORY include/

--- a/smacc2_sm_reference_library/sm_atomic_24hr/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_atomic_24hr/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries(${PROJECT_NAME}_node
   ${Boost_LIBRARIES}
 )
 
-ament_target_dependencies(${PROJECT_NAME}_node smacc2)
+target_link_libraries(${PROJECT_NAME}_node PUBLIC smacc2)
 
 install(
   DIRECTORY include/

--- a/smacc2_sm_reference_library/sm_atomic_hierarchy/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_atomic_hierarchy/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries(${PROJECT_NAME}_node
   ${Boost_LIBRARIES}
 )
 
-ament_target_dependencies(${PROJECT_NAME}_node smacc2)
+target_link_libraries(${PROJECT_NAME}_node PUBLIC smacc2)
 
 install(
   DIRECTORY include/

--- a/smacc2_sm_reference_library/sm_atomic_services/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_atomic_services/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(${PROJECT_NAME}_node
   ${std_srvs_LIBRARIES}
 )
 
-ament_target_dependencies(${PROJECT_NAME}_node smacc2)
+target_link_libraries(${PROJECT_NAME}_node PUBLIC smacc2)
 
 install(
   DIRECTORY include/

--- a/smacc2_sm_reference_library/sm_autoware_avp/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_autoware_avp/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(${PROJECT_NAME}_node
   ${Boost_LIBRARIES}
 )
 
-ament_target_dependencies(${PROJECT_NAME}_node ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(${PROJECT_NAME}_node PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 install(
   DIRECTORY include/

--- a/smacc2_sm_reference_library/sm_aws_warehouse_navigation/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_aws_warehouse_navigation/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(${PROJECT_NAME}_node
 )
 
 ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/sm_aws_warehouse_navigation.dsv.in")
-ament_target_dependencies(${PROJECT_NAME}_node smacc2)
+target_link_libraries(${PROJECT_NAME}_node PUBLIC smacc2)
 
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY models DESTINATION share/${PROJECT_NAME})

--- a/smacc2_sm_reference_library/sm_branching/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_branching/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(
   ${Boost_LIBRARIES}
 )
 
-ament_target_dependencies(${PROJECT_NAME}_node smacc2)
+target_link_libraries(${PROJECT_NAME}_node PUBLIC smacc2)
 
 install(DIRECTORY
   include/

--- a/smacc2_sm_reference_library/sm_dance_bot/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_dance_bot/CMakeLists.txt
@@ -60,14 +60,14 @@ add_executable(${PROJECT_NAME}_node
 add_executable(temperature_sensor_node_${PROJECT_NAME} servers/temperature_sensor_node/src/temperature_sensor_node.cpp)
 add_executable(led_action_server_node_${PROJECT_NAME} servers/led_action_server/src/led_action_server_node.cpp)
 
-ament_target_dependencies(${PROJECT_NAME}_node ${dependencies})
+target_link_libraries(${PROJECT_NAME}_node PUBLIC ${dependencies})
 target_link_libraries(${PROJECT_NAME}_node ${Boost_LIBS} ${PROJECT_NAME}__rosidl_typesupport_cpp)
 
-ament_target_dependencies(led_action_server_node_${PROJECT_NAME} ${dependencies})
+target_link_libraries(led_action_server_node_${PROJECT_NAME} PUBLIC ${dependencies})
 set_target_properties(led_action_server_node_${PROJECT_NAME} PROPERTIES OUTPUT_NAME "led_action_server_node")
 target_link_libraries(led_action_server_node_${PROJECT_NAME} ${Boost_LIBS} ${PROJECT_NAME}__rosidl_typesupport_cpp)
 
-ament_target_dependencies(temperature_sensor_node_${PROJECT_NAME} ${dependencies})
+target_link_libraries(temperature_sensor_node_${PROJECT_NAME} PUBLIC ${dependencies})
 set_target_properties(temperature_sensor_node_${PROJECT_NAME} PROPERTIES OUTPUT_NAME "temperature_sensor_node")
 
 ament_export_include_directories(include)

--- a/smacc2_sm_reference_library/sm_dance_bot_strikes_back/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_dance_bot_strikes_back/CMakeLists.txt
@@ -63,14 +63,14 @@ add_executable(
 add_executable(temperature_sensor_node_${PROJECT_NAME} servers/temperature_sensor_node/src/temperature_sensor_node.cpp)
 add_executable(led_action_server_node_${PROJECT_NAME} servers/led_action_server/src/led_action_server_node.cpp)
 
-ament_target_dependencies(${PROJECT_NAME}_node ${dependencies} rosidl_generator_cpp)
+target_link_libraries(${PROJECT_NAME}_node PUBLIC ${dependencies} rosidl_generator_cpp)
 target_link_libraries(${PROJECT_NAME}_node ${Boost_LIBS} ${PROJECT_NAME}__rosidl_typesupport_cpp)
 
-ament_target_dependencies(led_action_server_node_${PROJECT_NAME} ${dependencies})
+target_link_libraries(led_action_server_node_${PROJECT_NAME} PUBLIC ${dependencies})
 set_target_properties(led_action_server_node_${PROJECT_NAME} PROPERTIES OUTPUT_NAME "led_action_server_node")
 target_link_libraries(led_action_server_node_${PROJECT_NAME} ${Boost_LIBS} ${PROJECT_NAME}__rosidl_typesupport_cpp)
 
-ament_target_dependencies(temperature_sensor_node_${PROJECT_NAME} ${dependencies})
+target_link_libraries(temperature_sensor_node_${PROJECT_NAME} PUBLIC ${dependencies})
 set_target_properties(temperature_sensor_node_${PROJECT_NAME} PROPERTIES OUTPUT_NAME "temperature_sensor_node")
 
 ament_export_include_directories(include)

--- a/smacc2_sm_reference_library/sm_dance_bot_warehouse/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_dance_bot_warehouse/CMakeLists.txt
@@ -60,14 +60,14 @@ add_executable(${PROJECT_NAME}_node
 add_executable(temperature_sensor_node_${PROJECT_NAME} servers/temperature_sensor_node/src/temperature_sensor_node.cpp)
 add_executable(led_action_server_node_${PROJECT_NAME} servers/led_action_server/src/led_action_server_node.cpp)
 
-ament_target_dependencies(${PROJECT_NAME}_node ${dependencies})
+target_link_libraries(${PROJECT_NAME}_node PUBLIC ${dependencies})
 target_link_libraries(${PROJECT_NAME}_node ${Boost_LIBS} ${PROJECT_NAME}__rosidl_typesupport_cpp)
 
-ament_target_dependencies(led_action_server_node_${PROJECT_NAME} ${dependencies})
+target_link_libraries(led_action_server_node_${PROJECT_NAME} PUBLIC ${dependencies})
 set_target_properties(led_action_server_node_${PROJECT_NAME} PROPERTIES OUTPUT_NAME "led_action_server_node")
 target_link_libraries(led_action_server_node_${PROJECT_NAME} ${Boost_LIBS} ${PROJECT_NAME}__rosidl_typesupport_cpp)
 
-ament_target_dependencies(temperature_sensor_node_${PROJECT_NAME} ${dependencies})
+target_link_libraries(temperature_sensor_node_${PROJECT_NAME} PUBLIC ${dependencies})
 set_target_properties(temperature_sensor_node_${PROJECT_NAME} PROPERTIES OUTPUT_NAME "temperature_sensor_node")
 
 ament_export_include_directories(include)

--- a/smacc2_sm_reference_library/sm_dance_bot_warehouse_2/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_dance_bot_warehouse_2/CMakeLists.txt
@@ -60,14 +60,14 @@ add_executable(${PROJECT_NAME}_node
 add_executable(temperature_sensor_node_${PROJECT_NAME} servers/temperature_sensor_node/src/temperature_sensor_node.cpp)
 add_executable(led_action_server_node_${PROJECT_NAME} servers/led_action_server/src/led_action_server_node.cpp)
 
-ament_target_dependencies(${PROJECT_NAME}_node ${dependencies})
+target_link_libraries(${PROJECT_NAME}_node PUBLIC ${dependencies})
 target_link_libraries(${PROJECT_NAME}_node ${Boost_LIBS} ${PROJECT_NAME}__rosidl_typesupport_cpp)
 
-ament_target_dependencies(led_action_server_node_${PROJECT_NAME} ${dependencies})
+target_link_libraries(led_action_server_node_${PROJECT_NAME} PUBLIC ${dependencies})
 set_target_properties(led_action_server_node_${PROJECT_NAME} PROPERTIES OUTPUT_NAME "led_action_server_node")
 target_link_libraries(led_action_server_node_${PROJECT_NAME} ${Boost_LIBS} ${PROJECT_NAME}__rosidl_typesupport_cpp)
 
-ament_target_dependencies(temperature_sensor_node_${PROJECT_NAME} ${dependencies})
+target_link_libraries(temperature_sensor_node_${PROJECT_NAME} PUBLIC ${dependencies})
 set_target_properties(temperature_sensor_node_${PROJECT_NAME} PROPERTIES OUTPUT_NAME "temperature_sensor_node")
 
 ament_export_include_directories(include)

--- a/smacc2_sm_reference_library/sm_dance_bot_warehouse_3/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_dance_bot_warehouse_3/CMakeLists.txt
@@ -60,14 +60,14 @@ add_executable(${PROJECT_NAME}_node
 add_executable(temperature_sensor_node_${PROJECT_NAME} servers/temperature_sensor_node/src/temperature_sensor_node.cpp)
 add_executable(led_action_server_node_${PROJECT_NAME} servers/led_action_server/src/led_action_server_node.cpp)
 
-ament_target_dependencies(${PROJECT_NAME}_node ${dependencies})
+target_link_libraries(${PROJECT_NAME}_node PUBLIC ${dependencies})
 target_link_libraries(${PROJECT_NAME}_node ${Boost_LIBS} ${PROJECT_NAME}__rosidl_typesupport_cpp)
 
-ament_target_dependencies(led_action_server_node_${PROJECT_NAME} ${dependencies})
+target_link_libraries(led_action_server_node_${PROJECT_NAME} PUBLIC ${dependencies})
 set_target_properties(led_action_server_node_${PROJECT_NAME} PROPERTIES OUTPUT_NAME "led_action_server_node")
 target_link_libraries(led_action_server_node_${PROJECT_NAME} ${Boost_LIBS} ${PROJECT_NAME}__rosidl_typesupport_cpp)
 
-ament_target_dependencies(temperature_sensor_node_${PROJECT_NAME} ${dependencies})
+target_link_libraries(temperature_sensor_node_${PROJECT_NAME} PUBLIC ${dependencies})
 set_target_properties(temperature_sensor_node_${PROJECT_NAME} PROPERTIES OUTPUT_NAME "temperature_sensor_node")
 
 ament_export_include_directories(include)

--- a/smacc2_sm_reference_library/sm_husky_barrel_search_1/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_husky_barrel_search_1/CMakeLists.txt
@@ -62,7 +62,7 @@ add_executable(${PROJECT_NAME}_node
   src/${PROJECT_NAME}/sm_husky_barrel_search_1_node.cpp
 )
 
-ament_target_dependencies(${PROJECT_NAME}_node ${dependencies})
+target_link_libraries(${PROJECT_NAME}_node PUBLIC ${dependencies})
 target_link_libraries(${PROJECT_NAME}_node
   boost_thread
   boost_system
@@ -88,8 +88,10 @@ add_library(controllable_led_plugin SHARED
 
  target_include_directories(controllable_led_plugin PUBLIC include ${gazebo_ros_INCLUDE_DIRS})
 
- ament_target_dependencies(controllable_led_plugin
-   "std_msgs" ${dependencies})
+ target_link_libraries(controllable_led_plugin PUBLIC
+   "std_msgs"
+   ${dependencies}
+)
 
  target_link_libraries(controllable_led_plugin
  #/usr/lib/x86_64-linux-gnu/gazebo-11/plugins/libFlashLightPlugin.so
@@ -108,7 +110,7 @@ add_library(controllable_led_plugin SHARED
 add_executable(opencv_perception_node
   servers/opencv_perception_node/opencv_perception_node.cpp
 )
-ament_target_dependencies(opencv_perception_node ${dependencies})
+target_link_libraries(opencv_perception_node PUBLIC ${dependencies})
 
 target_link_libraries(opencv_perception_node
                         boost_thread

--- a/smacc2_sm_reference_library/sm_multi_stage_1/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_multi_stage_1/CMakeLists.txt
@@ -45,7 +45,7 @@ include_directories(include
 
 add_executable(${PROJECT_NAME}_node src/sm_multi_stage_1_node.cpp)
 
-ament_target_dependencies(${PROJECT_NAME}_node ${dependencies})
+target_link_libraries(${PROJECT_NAME}_node PUBLIC ${dependencies})
 ament_export_include_directories(include)
 
 target_link_libraries(${PROJECT_NAME}_node

--- a/smacc2_sm_reference_library/sm_multi_ur5_sim/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_multi_ur5_sim/CMakeLists.txt
@@ -40,7 +40,7 @@ target_link_libraries(${PROJECT_NAME}_node
   ${move_group_interface_client_LIBRARIES}
 )
 
-ament_target_dependencies(${PROJECT_NAME}_node ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(${PROJECT_NAME}_node PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 install(
   DIRECTORY include/

--- a/smacc2_sm_reference_library/sm_pack_ml/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_pack_ml/CMakeLists.txt
@@ -45,7 +45,7 @@ include_directories(include
 
 add_executable(${PROJECT_NAME}_node src/sm_pack_ml_node.cpp)
 
-ament_target_dependencies(${PROJECT_NAME}_node ${dependencies})
+target_link_libraries(${PROJECT_NAME}_node PUBLIC ${dependencies})
 ament_export_include_directories(include)
 
 target_link_libraries(${PROJECT_NAME}_node

--- a/smacc2_sm_reference_library/sm_pubsub_1/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_pubsub_1/CMakeLists.txt
@@ -50,9 +50,9 @@ target_link_libraries(
   ${keyboard_client_LIBRARIES}
   ${eg_conditional_generator_LIBRARIES})
 
-ament_target_dependencies(temperature_sensor_node smacc2)
+target_link_libraries(temperature_sensor_node PUBLIC smacc2)
 
-ament_target_dependencies(${PROJECT_NAME}_node smacc2)
+target_link_libraries(${PROJECT_NAME}_node PUBLIC smacc2)
 
 ament_package()
 

--- a/smacc2_sm_reference_library/sm_respira_1/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_respira_1/CMakeLists.txt
@@ -45,7 +45,7 @@ include_directories(include
 
 add_executable(${PROJECT_NAME}_node src/sm_respira_1_node.cpp)
 
-ament_target_dependencies(${PROJECT_NAME}_node ${dependencies})
+target_link_libraries(${PROJECT_NAME}_node PUBLIC ${dependencies})
 ament_export_include_directories(include)
 
 target_link_libraries(${PROJECT_NAME}_node

--- a/smacc2_sm_reference_library/sm_test_moveit_ur5_sim/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_test_moveit_ur5_sim/CMakeLists.txt
@@ -40,7 +40,7 @@ target_link_libraries(${PROJECT_NAME}_node
   ${move_group_interface_client_LIBRARIES}
 )
 
-ament_target_dependencies(${PROJECT_NAME}_node ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(${PROJECT_NAME}_node PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 install(
   DIRECTORY include/

--- a/smacc2_sm_reference_library/sm_three_some/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_three_some/CMakeLists.txt
@@ -37,7 +37,7 @@ set(dependencies
 
 add_executable(${PROJECT_NAME}_node src/sm_three_some_node.cpp)
 target_include_directories(${PROJECT_NAME}_node PUBLIC include)
-ament_target_dependencies(${PROJECT_NAME}_node
+target_link_libraries(${PROJECT_NAME}_node PUBLIC
   ${dependencies}
 )
 target_link_libraries(${PROJECT_NAME}_node

--- a/smacc2_state_reactor_library/sr_all_events_go/CMakeLists.txt
+++ b/smacc2_state_reactor_library/sr_all_events_go/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(${PROJECT_NAME} SHARED
   ${smacc2_LIBRARIES}
   ${smacc2_msgs_LIBRARIES}
 )
-ament_target_dependencies(${PROJECT_NAME} smacc2 smacc2_msgs)
+target_link_libraries(${PROJECT_NAME} PUBLIC smacc2 smacc2_msgs)
 
 ament_export_dependencies(smacc2)
 ament_export_include_directories(include)

--- a/smacc2_state_reactor_library/sr_conditional/CMakeLists.txt
+++ b/smacc2_state_reactor_library/sr_conditional/CMakeLists.txt
@@ -21,7 +21,7 @@ include_directories(include)
 add_library(${PROJECT_NAME} SHARED
             src/${PROJECT_NAME}/sr_conditional.cpp)
 
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
 
 ament_export_dependencies(${dependencies})
 ament_export_include_directories(include)

--- a/smacc2_state_reactor_library/sr_event_countdown/CMakeLists.txt
+++ b/smacc2_state_reactor_library/sr_event_countdown/CMakeLists.txt
@@ -23,7 +23,7 @@ include_directories(include)
 add_library(${PROJECT_NAME}
             src/${PROJECT_NAME}/sr_event_countdown.cpp)
 
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependencies})
 
 ament_export_dependencies(${dependencies})
 ament_export_include_directories(include)


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
