### PR TITLE
Fixed an UB in client_bases/smacc_subscriber_client.hpp

### DIFF
--- a/smacc2/include/smacc2/client_bases/smacc_subscriber_client.hpp
+++ b/smacc2/include/smacc2/client_bases/smacc_subscriber_client.hpp
@@ -45,9 +45,10 @@ public:
 
   SmaccSubscriberClient() { initialized_ = false; }
 
-  SmaccSubscriberClient(std::string topicname) {
+  SmaccSubscriberClient(std::string topicname)
+  {
     initialized_ = false;
-    topicName = topicname; 
+    topicName = topicname;
   }
 
   virtual ~SmaccSubscriberClient() {}

--- a/smacc2/include/smacc2/client_bases/smacc_subscriber_client.hpp
+++ b/smacc2/include/smacc2/client_bases/smacc_subscriber_client.hpp
@@ -45,7 +45,10 @@ public:
 
   SmaccSubscriberClient() { initialized_ = false; }
 
-  SmaccSubscriberClient(std::string topicname) { topicName = topicname; }
+  SmaccSubscriberClient(std::string topicname) {
+    initialized_ = false;
+    topicName = topicname; 
+  }
 
   virtual ~SmaccSubscriberClient() {}
 


### PR DESCRIPTION
Updated the `SmaccSubscriberClient(std::string topicname)` constructor to explicitly initialize `initialized_` to `false`, matching the default constructor's behavior.