### PR TITLE
Release 2.3.20 - Fix double onExit() calls (#556)

### DIFF
--- a/smacc2/CHANGELOG.rst
+++ b/smacc2/CHANGELOG.rst
@@ -1,6 +1,59 @@
 Changelog for package smacc2
 ================================
 
+2.3.20 (2025-01-XX)
+-------------------
+### Fixed
+- **CRITICAL**: Fix double onExit() calls in client behaviors (`#556 <https://github.com/robosoft-ai/SMACC2/issues/556>`_, `#558 <https://github.com/robosoft-ai/SMACC2/issues/558>`_)
+
+  Client behavior's onExit method was being invoked twice during state transitions due to
+  duplicate notifyOnStateExitting() call. This caused issues including deadlocks in behaviors
+  with thread joins in onExit. Fixed by removing redundant call outside mutex lock.
+
+  - Root cause identified by @yassiezar
+  - Issue reported in apt packages by @Crowdedlight
+
+- Fix toggle functionality (`#587 <https://github.com/robosoft-ai/SMACC2/issues/587>`_)
+
+### Added
+- New cl_moveit2z client library (`#638 <https://github.com/robosoft-ai/SMACC2/issues/638>`_)
+- New cl_keyboard client and removal of sm_pubsub_1 (`#621 <https://github.com/robosoft-ai/SMACC2/issues/621>`_)
+- New cl_ros2_timer unit test (`#616 <https://github.com/robosoft-ai/SMACC2/issues/616>`_)
+- Nova Carter navigation behaviors (`#608 <https://github.com/robosoft-ai/SMACC2/issues/608>`_)
+- Progress on requiresComponent (`#628 <https://github.com/robosoft-ai/SMACC2/issues/628>`_)
+
+### Changed
+- Refactoring of cl_moveit2z to component-based architecture & header-only implementation (`#639 <https://github.com/robosoft-ai/SMACC2/issues/639>`_)
+- Refactoring cl_nav2z to remove legacy API support and update client behaviors (`#625 <https://github.com/robosoft-ai/SMACC2/issues/625>`_)
+- Refactor of cl_nav2z to component-based architecture (`#624 <https://github.com/robosoft-ai/SMACC2/issues/624>`_)
+- Refactor of cl_nav2z, moved cp_nav2_action_interface.hpp into folder (`#626 <https://github.com/robosoft-ai/SMACC2/issues/626>`_)
+- Refactor of cl_ros2_timer namespace structure (include paths) (`#623 <https://github.com/robosoft-ai/SMACC2/issues/623>`_)
+- Refactored cl_ros2_timer components to header-only (`#619 <https://github.com/robosoft-ai/SMACC2/issues/619>`_)
+- Refactoring cl_ros2_timer to component-based architecture (`#618 <https://github.com/robosoft-ai/SMACC2/issues/618>`_)
+- Refactoring cl_ros2_timer to header-lite (`#617 <https://github.com/robosoft-ai/SMACC2/issues/617>`_)
+- Final keyboard client refactor changes with formatting (`#599 <https://github.com/robosoft-ai/SMACC2/issues/599>`_)
+- Refactor keyboard client to remove cb.cpp file (`#609 <https://github.com/robosoft-ai/SMACC2/issues/609>`_)
+- Refactoring: renaming onOrthogonalAllocation (`#600 <https://github.com/robosoft-ai/SMACC2/issues/600>`_)
+- Refactor base components (`#606 <https://github.com/robosoft-ai/SMACC2/issues/606>`_)
+- sm_panda_moveit2z_cb_inventory refactor (`#633 <https://github.com/robosoft-ai/SMACC2/issues/633>`_)
+- Moving reference library from ros_timer_client and keyboard_client to cl_ros2_timer and cl_keyboard (`#645 <https://github.com/robosoft-ai/SMACC2/issues/645>`_)
+- Trimming sm_atomic_services and sm_atomic_24hr from sm_reference_library (`#644 <https://github.com/robosoft-ai/SMACC2/issues/644>`_)
+- Update ROS distribution from Galactic to Humble (`#631 <https://github.com/robosoft-ai/SMACC2/issues/631>`_)
+- Update include path for cl_ros2_timer (`#629 <https://github.com/robosoft-ai/SMACC2/issues/629>`_)
+
+### Documentation
+- Updating CLAUDE.md files (`#643 <https://github.com/robosoft-ai/SMACC2/issues/643>`_)
+- CLAUDE.MD file for client behavior libraries (`#586 <https://github.com/robosoft-ai/SMACC2/issues/586>`_)
+- Fixing sm readmes (`#632 <https://github.com/robosoft-ai/SMACC2/issues/632>`_)
+- Updating sm_simple_action_client launch file (`#642 <https://github.com/robosoft-ai/SMACC2/issues/642>`_)
+- Update README.md (`#576 <https://github.com/robosoft-ai/SMACC2/issues/576>`_)
+
+### Contributors
+- Pablo Iñigo Blasco (@pabloinigoblasco)
+- Brett Aldrich (@brettpac)
+- Jaycee Lock (@yassiezar)
+- Crowdedlight (@Crowdedlight)
+
 0.4.0 (2022-04-04)
 ------------------
 ### Added

--- a/smacc2/package.xml
+++ b/smacc2/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>smacc2</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
 
   <description>An Event-Driven, Asynchronous, Behavioral State Machine Library for ROS2 (Robotic Operating System) applications written in C++.</description>
 

--- a/smacc2_client_library/cl_keyboard/package.xml
+++ b/smacc2_client_library/cl_keyboard/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
  <name>cl_keyboard</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The cl_keyboard package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_client_library/cl_moveit2z/package.xml
+++ b/smacc2_client_library/cl_moveit2z/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>cl_moveit2z</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
 
   <description>The cl_moveit2z package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Iñigo Blasco</maintainer>

--- a/smacc2_client_library/cl_nav2z/package.xml
+++ b/smacc2_client_library/cl_nav2z/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>cl_nav2z</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The cl_nav2z package implements SMACC Action Client Plugin for the ROS Navigation State - move_base node.  Developed by Reel Robotics.</description>
 
   <author email="pablo@ibrobotics.com">Pablo Inigo Blasco</author>

--- a/smacc2_client_library/cl_ros2_timer/package.xml
+++ b/smacc2_client_library/cl_ros2_timer/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>cl_ros2_timer</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The cl_ros2_timer package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_client_library/http_client/package.xml
+++ b/smacc2_client_library/http_client/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
  <name>http_client</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The http_client package</description>
   <maintainer email="jaycee.lock@proton.me">Jaycee Lock</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_client_library/keyboard_client/package.xml
+++ b/smacc2_client_library/keyboard_client/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
  <name>keyboard_client</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The keyboard_client package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_client_library/lifecyclenode_client/package.xml
+++ b/smacc2_client_library/lifecyclenode_client/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>lifecyclenode_client</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The lifecyclenode_client package implements SMACC Action Client Plugin for the ROS Navigation State - move_base node.  Developed by Reel Robotics.</description>
 
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>

--- a/smacc2_client_library/moveit2z_client/package.xml
+++ b/smacc2_client_library/moveit2z_client/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>moveit2z_client</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
 
   <description>The moveit2z_client package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Iñigo Blasco</maintainer>

--- a/smacc2_client_library/multirole_sensor_client/package.xml
+++ b/smacc2_client_library/multirole_sensor_client/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>multirole_sensor_client</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The multirole_sensor_client package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Iñigo Blasco</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_client_library/nav2z_client/custom_planners/backward_global_planner/package.xml
+++ b/smacc2_client_library/nav2z_client/custom_planners/backward_global_planner/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>backward_global_planner</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The backward_global_planner package.</description>
 
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>

--- a/smacc2_client_library/nav2z_client/custom_planners/backward_local_planner/package.xml
+++ b/smacc2_client_library/nav2z_client/custom_planners/backward_local_planner/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>backward_local_planner</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The backward_local_planner package.</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
   <author email="pablo@ibrobotics.com">Pablo Inigo Blasco</author>

--- a/smacc2_client_library/nav2z_client/custom_planners/forward_global_planner/package.xml
+++ b/smacc2_client_library/nav2z_client/custom_planners/forward_global_planner/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>forward_global_planner</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The forward_global_planner package.</description>
 
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>

--- a/smacc2_client_library/nav2z_client/custom_planners/forward_local_planner/package.xml
+++ b/smacc2_client_library/nav2z_client/custom_planners/forward_local_planner/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>forward_local_planner</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>forward_local_planner package.</description>
 
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>

--- a/smacc2_client_library/nav2z_client/custom_planners/nav2z_planners_common/package.xml
+++ b/smacc2_client_library/nav2z_client/custom_planners/nav2z_planners_common/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nav2z_planners_common</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The nav2z_planners_common package.</description>
 
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>

--- a/smacc2_client_library/nav2z_client/custom_planners/pure_spinning_local_planner/package.xml
+++ b/smacc2_client_library/nav2z_client/custom_planners/pure_spinning_local_planner/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>pure_spinning_local_planner</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The pure_spinning_local_planner package</description>
 
   <maintainer email="pablo@ibrobotics.com">Pablo Iñigo Blasco</maintainer>

--- a/smacc2_client_library/nav2z_client/custom_planners/undo_path_global_planner/package.xml
+++ b/smacc2_client_library/nav2z_client/custom_planners/undo_path_global_planner/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>undo_path_global_planner</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The undo_path_global_planner package.</description>
 
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>

--- a/smacc2_client_library/nav2z_client/nav2z_client/package.xml
+++ b/smacc2_client_library/nav2z_client/nav2z_client/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nav2z_client</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The nav2z_client package implements SMACC Action Client Plugin for the ROS Navigation State - move_base node.  Developed by Reel Robotics.</description>
 
   <author email="pablo@ibrobotics.com">Pablo Inigo Blasco</author>

--- a/smacc2_client_library/ros_timer_client/package.xml
+++ b/smacc2_client_library/ros_timer_client/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros_timer_client</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The ros_timer_client package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_event_generator_library/eg_conditional_generator/package.xml
+++ b/smacc2_event_generator_library/eg_conditional_generator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>eg_conditional_generator</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The eg_random_generator package</description>
 
   <maintainer email="pablo@ibrobotics.com">Pablo Iñigo Blasco</maintainer>

--- a/smacc2_event_generator_library/eg_random_generator/package.xml
+++ b/smacc2_event_generator_library/eg_random_generator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>eg_random_generator</name>
-   <version>2.3.19</version>
+   <version>2.3.20</version>
    <description>The eg_random_generator package</description>
    <maintainer email="pablo@ibrobotics.com">Pablo Iñigo Blasco</maintainer>
    <license>Apache-2.0</license>

--- a/smacc2_msgs/package.xml
+++ b/smacc2_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>smacc2_msgs</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
 
   <description>Messages and services used in smacc2.</description>
 

--- a/smacc2_performance_tools/performance_tests/sm_atomic_performance_trace_1/package.xml
+++ b/smacc2_performance_tools/performance_tests/sm_atomic_performance_trace_1/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sm_atomic_performance_trace_1</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sm_atomic_performance_trace_1 package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_performance_tools/performance_tests/sm_atomic_subscribers_performance_test/package.xml
+++ b/smacc2_performance_tools/performance_tests/sm_atomic_subscribers_performance_test/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sm_atomic_subscribers_performance_test</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sm_atomic_subscribers_performance_test package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_performance_tools/performance_tests/sm_coretest_transition_speed_1/package.xml
+++ b/smacc2_performance_tools/performance_tests/sm_coretest_transition_speed_1/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sm_coretest_transition_speed_1</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sm_coretest_transition_speed_1 package</description>
   <maintainer email="smacc2@smacc2.cool">SMACC2 is cool</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_sm_reference_library/sm_advanced_recovery_1/package.xml
+++ b/smacc2_sm_reference_library/sm_advanced_recovery_1/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sm_advanced_recovery_1</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sm_advanced_recovery_1 package</description>
   <maintainer email="pablo@ibrobotics.com">geus</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_sm_reference_library/sm_atomic/package.xml
+++ b/smacc2_sm_reference_library/sm_atomic/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sm_atomic</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sm_atomic package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_sm_reference_library/sm_atomic_http/package.xml
+++ b/smacc2_sm_reference_library/sm_atomic_http/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sm_atomic_http</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sm_atomic_http package</description>
   <maintainer email="jaycee.lock@gmail.com">Jaycee Lock</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_sm_reference_library/sm_atomic_lifecycle/package.xml
+++ b/smacc2_sm_reference_library/sm_atomic_lifecycle/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sm_atomic_lifecycle</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sm_atomic_lifecycle package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_sm_reference_library/sm_atomic_mode_states/package.xml
+++ b/smacc2_sm_reference_library/sm_atomic_mode_states/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sm_atomic_mode_states</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sm_atomic_mode_states package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_sm_reference_library/sm_branching/package.xml
+++ b/smacc2_sm_reference_library/sm_branching/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sm_branching</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sm_branching package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_sm_reference_library/sm_cl_keyboard_unit_test_1/package.xml
+++ b/smacc2_sm_reference_library/sm_cl_keyboard_unit_test_1/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sm_cl_keyboard_unit_test_1</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sm_cl_keyboard_unit_test_1 package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_sm_reference_library/sm_cl_ros2_timer_unit_test_1/package.xml
+++ b/smacc2_sm_reference_library/sm_cl_ros2_timer_unit_test_1/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sm_cl_ros2_timer_unit_test_1</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sm_cl_ros2_timer_unit_test_1 package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_sm_reference_library/sm_multi_stage_1/package.xml
+++ b/smacc2_sm_reference_library/sm_multi_stage_1/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sm_multi_stage_1</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sm_multi_stage_1 package</description>
   <maintainer email="pablo@ibrobotics.com">geus</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_sm_reference_library/sm_pack_ml/package.xml
+++ b/smacc2_sm_reference_library/sm_pack_ml/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sm_pack_ml</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sm_pack_ml package</description>
   <maintainer email="pablo@ibrobotics.com">geus</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_sm_reference_library/sm_panda_cl_moveit2z_cb_inventory/package.xml
+++ b/smacc2_sm_reference_library/sm_panda_cl_moveit2z_cb_inventory/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sm_panda_cl_moveit2z_cb_inventory</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sm_panda_cl_moveit2z_cb_inventory package</description>
   <maintainer email="smacc2@smacc2.cool">SMACC2 is cool</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_sm_reference_library/sm_panda_moveit2z_cb_inventory/package.xml
+++ b/smacc2_sm_reference_library/sm_panda_moveit2z_cb_inventory/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sm_panda_moveit2z_cb_inventory</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sm_panda_moveit2z_cb_inventory package</description>
   <maintainer email="smacc2@smacc2.cool">SMACC2 is cool</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_sm_reference_library/sm_simple_action_client/package.xml
+++ b/smacc2_sm_reference_library/sm_simple_action_client/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sm_simple_action_client</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sm_simple_action_client package</description>
   <maintainer email="smacc2@smacc2.cool">SMACC2 is cool</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_sm_reference_library/sm_three_some/package.xml
+++ b/smacc2_sm_reference_library/sm_three_some/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sm_three_some</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sm_three_some package</description>
   <maintainer email="techsupport@robosoft.ai">Brett Aldrich</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_state_reactor_library/sr_all_events_go/package.xml
+++ b/smacc2_state_reactor_library/sr_all_events_go/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sr_all_events_go</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sr_all_events_go package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Iñigo Blasco</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_state_reactor_library/sr_conditional/package.xml
+++ b/smacc2_state_reactor_library/sr_conditional/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
 <name>sr_conditional</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sr_conditional package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
   <license>Apache-2.0</license>

--- a/smacc2_state_reactor_library/sr_event_countdown/package.xml
+++ b/smacc2_state_reactor_library/sr_event_countdown/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
 <name>sr_event_countdown</name>
-  <version>2.3.19</version>
+  <version>2.3.20</version>
   <description>The sr_event_countdown package</description>
   <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
## Release 2.3.20

  This release primarily addresses the critical **double onExit() bug (#556)** that affects all client behaviors during state transitions.

  ### Critical Fix
  - ✅ Fix double onExit() calls in client behaviors (#558)
    - Client behaviors' onExit was called twice due to duplicate notifyOnStateExitting()
    - Caused deadlocks in behaviors with thread joins
    - Root cause identified by @yassiezar
    - Reported in apt packages by @Crowdedlight

  ### Changes
  - Updated all 42 packages from 2.3.19 → 2.3.20
  - Comprehensive CHANGELOG entry added
  - 54 commits since 2.3.19 including new cl_moveit2z and major refactoring

  ### Testing
  Once merged and bloom release completes, apt users can update:
  ```bash
  sudo apt update
  sudo apt install --only-upgrade ros-humble-smacc2

  Fixes #556
