### PR TITLE
Added missing header dependency to smacc_orthogonal_impl.hpp - Issue #559

### DIFF
--- a/smacc2/include/smacc2/impl/smacc_orthogonal_impl.hpp
+++ b/smacc2/include/smacc2/impl/smacc_orthogonal_impl.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 #include <cassert>
+#include <smacc2/introspection/introspection.hpp>
 #include <smacc2/smacc_client.hpp>
 #include <smacc2/smacc_orthogonal.hpp>
 


### PR DESCRIPTION
✅ Issue #559 Fixed Successfully

  Summary

  Fixed missing header dependency in smacc_orthogonal_impl.hpp by adding explicit include for introspection.hpp.

  Changes Made

  File: /workspaces/isaac_ros-dev/src/SMACC2/smacc2/include/smacc2/impl/smacc_orthogonal_impl.hpp

  Change: Added line 23:
  #include <smacc2/introspection/introspection.hpp>

  This explicitly declares the dependency on demangledTypeName<>() used at lines 37, 182, and 183.

  Verification Results

  ✅ Build Status: Compilation successful (12.1s)✅ No Errors: Zero compilation errors✅ Warnings: Only pre-existing unrelated warnings (unused parameters in other files)✅ No Circular Dependencies:
  Verified against all other impl files✅ Pattern Consistency: Now matches include pattern used in all other impl files

  Impact

  - Code Quality: Header is now self-contained per C++ best practices
  - Maintainability: Dependencies are explicit and documented
  - Robustness: No longer relies on fragile transitive includes
  - Performance: Zero overhead (header already transitively included)
  - Compatibility: Zero breaking changes
