### PR TITLE
Refactoring lifecyclenode_client to pure component based architecture, creation of core cp_service_client component

### DIFF
--- a/smacc2/include/smacc2/client_core_components/cp_service_client.hpp
+++ b/smacc2/include/smacc2/client_core_components/cp_service_client.hpp
@@ -1,0 +1,387 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/component.hpp>
+#include <smacc2/smacc_default_events.hpp>
+#include <smacc2/smacc_signal.hpp>
+#include <smacc2/smacc_state_machine.hpp>
+
+#include <chrono>
+#include <functional>
+#include <future>
+#include <mutex>
+#include <optional>
+#include <rclcpp/rclcpp.hpp>
+
+namespace smacc2
+{
+namespace client_core_components
+{
+using namespace smacc2::default_events;
+
+/**
+ * @brief Generic ROS2 service client component for SMACC2
+ *
+ * CpServiceClient provides a reusable service client component that can be used
+ * by any SMACC2 client library requiring ROS2 service communication. It follows
+ * the same pattern as CpActionClient, providing signals, event posting, and
+ * thread-safe service call management.
+ *
+ * Key Features:
+ * - Template-based for type safety with any ROS2 service type
+ * - SMACC2 signal integration for event-driven responses
+ * - Automatic SMACC2 event posting via template configuration
+ * - Both synchronous and asynchronous service call support
+ * - Thread-safe service call execution
+ * - Service availability checking and waiting
+ *
+ * Usage Example:
+ * @code
+ * // In your client's onInitialize():
+ * auto serviceClient = this->createComponent<
+ *   smacc2::client_core_components::CpServiceClient<my_msgs::srv::MyService>>(
+ *   "/my_service_name");
+ *
+ * // Send a request:
+ * auto request = std::make_shared<my_msgs::srv::MyService::Request>();
+ * request->data = 42;
+ * serviceClient->sendRequestSync(request);
+ * @endcode
+ *
+ * @tparam ServiceType ROS2 service type (e.g., std_srvs::srv::SetBool)
+ */
+template <typename ServiceType>
+class CpServiceClient : public smacc2::ISmaccComponent
+{
+public:
+  // Type aliases for cleaner code
+  using Client = rclcpp::Client<ServiceType>;
+  using Request = typename ServiceType::Request;
+  using Response = typename ServiceType::Response;
+  using SharedRequest = typename Request::SharedPtr;
+  using SharedResponse = typename Response::SharedPtr;
+  using SharedFuture = typename rclcpp::Client<ServiceType>::SharedFuture;
+
+  // Configuration options (set before onInitialize() or via constructor)
+  std::optional<std::string> serviceName;
+  std::optional<std::chrono::milliseconds> serviceTimeout;
+
+  // SMACC2 Signals for component communication
+  // These signals are emitted when service events occur, allowing other
+  // components and behaviors to react to service responses
+  smacc2::SmaccSignal<void(const SharedResponse &)> onServiceResponse_;
+  smacc2::SmaccSignal<void()> onServiceRequestSent_;
+  smacc2::SmaccSignal<void()> onServiceFailure_;
+
+  // Event posting functions (configured during component initialization)
+  // These lambdas are set up with proper template parameters to post
+  // type-safe SMACC2 events to the state machine
+  std::function<void(const SharedResponse &)> postResponseEvent;
+  std::function<void()> postRequestSentEvent;
+  std::function<void()> postFailureEvent;
+
+  /**
+   * @brief Default constructor
+   */
+  CpServiceClient() = default;
+
+  /**
+   * @brief Constructor with service name
+   * @param serviceName ROS2 service name (e.g., "/my_node/my_service")
+   */
+  CpServiceClient(const std::string & serviceName) : serviceName(serviceName) {}
+
+  /**
+   * @brief Constructor with service name and timeout
+   * @param serviceName ROS2 service name
+   * @param serviceTimeout Maximum time to wait for service response
+   */
+  CpServiceClient(
+    const std::string & serviceName, std::chrono::milliseconds serviceTimeout)
+  : serviceName(serviceName), serviceTimeout(serviceTimeout)
+  {
+  }
+
+  virtual ~CpServiceClient() = default;
+
+  /**
+   * @brief Send a service request asynchronously
+   *
+   * Sends a service request and returns a future. The caller can wait on
+   * the future or let the component handle the response via signals/events.
+   *
+   * @param request Shared pointer to the service request
+   * @return SharedFuture Future for the service response
+   */
+  SharedFuture sendRequest(SharedRequest request)
+  {
+    std::lock_guard<std::mutex> lock(serviceMutex_);
+
+    if (!client_)
+    {
+      RCLCPP_ERROR_STREAM(
+        getLogger(), "[" << this->getName() << "] Service client not initialized!");
+      throw std::runtime_error("Service client not initialized");
+    }
+
+    if (!client_->service_is_ready())
+    {
+      RCLCPP_WARN_STREAM(
+        getLogger(),
+        "[" << this->getName() << "] Service not ready: " << *serviceName);
+    }
+
+    RCLCPP_INFO_STREAM(
+      getLogger(), "[" << this->getName() << "] Sending service request to: " << *serviceName);
+
+    // Send the async request
+    auto future = client_->async_send_request(request);
+    lastRequest_ = future;
+
+    // Emit signal that request was sent
+    onServiceRequestSent_();
+    if (postRequestSentEvent) postRequestSentEvent();
+
+    return future;
+  }
+
+  /**
+   * @brief Send a service request synchronously (blocking)
+   *
+   * Sends a service request and blocks until the response is received or
+   * a timeout occurs. This is a convenience method that wraps sendRequest()
+   * with a blocking wait.
+   *
+   * @param request Shared pointer to the service request
+   * @return SharedResponse Response from the service
+   * @throws std::runtime_error if service call fails or times out
+   */
+  SharedResponse sendRequestSync(SharedRequest request)
+  {
+    auto future = sendRequest(request);
+
+    // Wait for response with timeout
+    std::future_status status;
+    if (serviceTimeout)
+    {
+      status = future.wait_for(*serviceTimeout);
+      if (status == std::future_status::timeout)
+      {
+        RCLCPP_ERROR_STREAM(
+          getLogger(), "[" << this->getName() << "] Service call timed out: " << *serviceName);
+        onServiceFailure_();
+        if (postFailureEvent) postFailureEvent();
+        throw std::runtime_error("Service call timeout");
+      }
+    }
+    else
+    {
+      future.wait();
+    }
+
+    // Get the response
+    try
+    {
+      auto response = future.get();
+
+      RCLCPP_INFO_STREAM(
+        getLogger(), "[" << this->getName() << "] Service response received from: " << *serviceName);
+
+      // Emit signals and events
+      onServiceResponse_(response);
+      if (postResponseEvent) postResponseEvent(response);
+
+      return response;
+    }
+    catch (const std::exception & e)
+    {
+      RCLCPP_ERROR_STREAM(
+        getLogger(),
+        "[" << this->getName() << "] Service call failed: " << *serviceName << " - " << e.what());
+      onServiceFailure_();
+      if (postFailureEvent) postFailureEvent();
+      throw;
+    }
+  }
+
+  /**
+   * @brief Check if the service server is ready
+   * @return true if service is available, false otherwise
+   */
+  bool isServiceReady() const
+  {
+    return client_ && client_->service_is_ready();
+  }
+
+  /**
+   * @brief Wait for the service to become available
+   *
+   * Blocks until the service server is ready to accept requests.
+   * Uses a default timeout or the configured serviceTimeout.
+   */
+  void waitForService()
+  {
+    if (client_)
+    {
+      RCLCPP_INFO_STREAM(
+        getLogger(), "[" << this->getName() << "] Waiting for service: " << *serviceName);
+
+      if (serviceTimeout)
+      {
+        auto timeout = std::chrono::duration_cast<std::chrono::nanoseconds>(*serviceTimeout);
+        if (!client_->wait_for_service(timeout))
+        {
+          RCLCPP_WARN_STREAM(
+            getLogger(),
+            "[" << this->getName() << "] Service wait timed out: " << *serviceName);
+        }
+      }
+      else
+      {
+        client_->wait_for_service();
+      }
+
+      RCLCPP_INFO_STREAM(
+        getLogger(), "[" << this->getName() << "] Service ready: " << *serviceName);
+    }
+  }
+
+  /**
+   * @brief Component initialization - creates the ROS2 service client
+   *
+   * Called by SMACC2 framework during component initialization.
+   * Creates the underlying rclcpp::Client for the specified service.
+   */
+  void onInitialize() override
+  {
+    if (!serviceName)
+    {
+      RCLCPP_ERROR_STREAM(getLogger(), "[" << this->getName() << "] Service name not set!");
+      return;
+    }
+
+    RCLCPP_INFO_STREAM(
+      getLogger(),
+      "[" << this->getName() << "] Initializing service client for: " << *serviceName);
+
+    client_ = getNode()->create_client<ServiceType>(*serviceName);
+
+    RCLCPP_INFO_STREAM(
+      getLogger(),
+      "[" << this->getName() << "] DONE Initializing service client for: " << *serviceName);
+  }
+
+  /**
+   * @brief Configure event posting with proper template parameters
+   *
+   * This method is called during component allocation to set up the event
+   * posting lambdas with the correct orthogonal and source object types.
+   * This enables type-safe event posting to the state machine.
+   *
+   * @tparam TOrthogonal The orthogonal type that owns this component
+   * @tparam TSourceObject The source object type (typically the client)
+   */
+  template <typename TOrthogonal, typename TSourceObject>
+  void onComponentInitialization()
+  {
+    // Set up event posting functions with proper template parameters
+    postResponseEvent = [this](const SharedResponse & response)
+    {
+      auto * ev = new EvServiceResponse<TSourceObject, TOrthogonal, Response>();
+      ev->response = *response;
+      this->postEvent(ev);
+      RCLCPP_DEBUG(getLogger(), "[%s] SERVICE RESPONSE EVENT", this->getName().c_str());
+    };
+
+    postRequestSentEvent = [this]()
+    {
+      auto * ev = new EvServiceRequestSent<TSourceObject, TOrthogonal>();
+      this->postEvent(ev);
+      RCLCPP_DEBUG(getLogger(), "[%s] SERVICE REQUEST SENT EVENT", this->getName().c_str());
+    };
+
+    postFailureEvent = [this]()
+    {
+      auto * ev = new EvServiceFailure<TSourceObject, TOrthogonal>();
+      this->postEvent(ev);
+      RCLCPP_DEBUG(getLogger(), "[%s] SERVICE FAILURE EVENT", this->getName().c_str());
+    };
+  }
+
+  /**
+   * @brief Helper method to connect a callback to the response signal
+   *
+   * Provides a convenient way to connect member functions to the service
+   * response signal with proper lifetime management.
+   *
+   * @tparam T Type of the callback object
+   * @param callback Member function pointer to call on response
+   * @param object Object instance that owns the callback
+   * @return Signal connection handle
+   */
+  template <typename T>
+  boost::signals2::connection onResponse(
+    void (T::*callback)(const SharedResponse &), T * object)
+  {
+    return this->getStateMachine()->createSignalConnection(onServiceResponse_, callback, object);
+  }
+
+  /**
+   * @brief Helper method to connect a callback to the request sent signal
+   *
+   * @tparam T Type of the callback object
+   * @param callback Member function pointer to call when request is sent
+   * @param object Object instance that owns the callback
+   * @return Signal connection handle
+   */
+  template <typename T>
+  boost::signals2::connection onRequestSent(void (T::*callback)(), T * object)
+  {
+    return this->getStateMachine()->createSignalConnection(
+      onServiceRequestSent_, callback, object);
+  }
+
+  /**
+   * @brief Helper method to connect a callback to the failure signal
+   *
+   * @tparam T Type of the callback object
+   * @param callback Member function pointer to call on failure
+   * @param object Object instance that owns the callback
+   * @return Signal connection handle
+   */
+  template <typename T>
+  boost::signals2::connection onFailure(void (T::*callback)(), T * object)
+  {
+    return this->getStateMachine()->createSignalConnection(onServiceFailure_, callback, object);
+  }
+
+  /**
+   * @brief Get the underlying ROS2 service client
+   *
+   * Provides access to the raw rclcpp::Client for advanced usage scenarios.
+   *
+   * @return Shared pointer to the rclcpp service client
+   */
+  std::shared_ptr<Client> getServiceClient() const { return client_; }
+
+private:
+  std::shared_ptr<Client> client_ = nullptr;
+  std::optional<SharedFuture> lastRequest_;
+  std::mutex serviceMutex_;
+};
+
+}  // namespace client_core_components
+}  // namespace smacc2

--- a/smacc2/include/smacc2/client_core_components/cp_service_client.hpp
+++ b/smacc2/include/smacc2/client_core_components/cp_service_client.hpp
@@ -109,8 +109,7 @@ public:
    * @param serviceName ROS2 service name
    * @param serviceTimeout Maximum time to wait for service response
    */
-  CpServiceClient(
-    const std::string & serviceName, std::chrono::milliseconds serviceTimeout)
+  CpServiceClient(const std::string & serviceName, std::chrono::milliseconds serviceTimeout)
   : serviceName(serviceName), serviceTimeout(serviceTimeout)
   {
   }
@@ -140,8 +139,7 @@ public:
     if (!client_->service_is_ready())
     {
       RCLCPP_WARN_STREAM(
-        getLogger(),
-        "[" << this->getName() << "] Service not ready: " << *serviceName);
+        getLogger(), "[" << this->getName() << "] Service not ready: " << *serviceName);
     }
 
     RCLCPP_INFO_STREAM(
@@ -198,7 +196,8 @@ public:
       auto response = future.get();
 
       RCLCPP_INFO_STREAM(
-        getLogger(), "[" << this->getName() << "] Service response received from: " << *serviceName);
+        getLogger(),
+        "[" << this->getName() << "] Service response received from: " << *serviceName);
 
       // Emit signals and events
       onServiceResponse_(response);
@@ -221,10 +220,7 @@ public:
    * @brief Check if the service server is ready
    * @return true if service is available, false otherwise
    */
-  bool isServiceReady() const
-  {
-    return client_ && client_->service_is_ready();
-  }
+  bool isServiceReady() const { return client_ && client_->service_is_ready(); }
 
   /**
    * @brief Wait for the service to become available
@@ -245,8 +241,7 @@ public:
         if (!client_->wait_for_service(timeout))
         {
           RCLCPP_WARN_STREAM(
-            getLogger(),
-            "[" << this->getName() << "] Service wait timed out: " << *serviceName);
+            getLogger(), "[" << this->getName() << "] Service wait timed out: " << *serviceName);
         }
       }
       else
@@ -274,8 +269,7 @@ public:
     }
 
     RCLCPP_INFO_STREAM(
-      getLogger(),
-      "[" << this->getName() << "] Initializing service client for: " << *serviceName);
+      getLogger(), "[" << this->getName() << "] Initializing service client for: " << *serviceName);
 
     client_ = getNode()->create_client<ServiceType>(*serviceName);
 
@@ -333,8 +327,7 @@ public:
    * @return Signal connection handle
    */
   template <typename T>
-  boost::signals2::connection onResponse(
-    void (T::*callback)(const SharedResponse &), T * object)
+  boost::signals2::connection onResponse(void (T::*callback)(const SharedResponse &), T * object)
   {
     return this->getStateMachine()->createSignalConnection(onServiceResponse_, callback, object);
   }
@@ -350,8 +343,7 @@ public:
   template <typename T>
   boost::signals2::connection onRequestSent(void (T::*callback)(), T * object)
   {
-    return this->getStateMachine()->createSignalConnection(
-      onServiceRequestSent_, callback, object);
+    return this->getStateMachine()->createSignalConnection(onServiceRequestSent_, callback, object);
   }
 
   /**

--- a/smacc2/include/smacc2/smacc_default_events.hpp
+++ b/smacc2/include/smacc2/smacc_default_events.hpp
@@ -104,6 +104,50 @@ struct EvActionCancelled : sc::event<EvActionCancelled<TSource, TOrthogonal>>
   static std::string getDefaultTransitionType() { return demangledTypeName<CANCEL>(); }
 };
 
+//-------------- SERVICE EVENTS --------------------------------------------------------
+template <typename TSource, typename TOrthogonal, typename TResponse>
+struct EvServiceResponse : sc::event<EvServiceResponse<TSource, TOrthogonal, TResponse>>
+{
+  TResponse response;
+
+  static std::string getEventLabel()
+  {
+    std::string label;
+    EventLabel<TSource>(label);
+    return label;
+  }
+
+  static std::string getDefaultTransitionTag() { return demangledTypeName<SUCCESS>(); }
+
+  static std::string getDefaultTransitionType() { return demangledTypeName<SUCCESS>(); }
+};
+
+template <typename TSource, typename TOrthogonal>
+struct EvServiceRequestSent : sc::event<EvServiceRequestSent<TSource, TOrthogonal>>
+{
+  static std::string getEventLabel()
+  {
+    std::string label;
+    EventLabel<TSource>(label);
+    return label;
+  }
+};
+
+template <typename TSource, typename TOrthogonal>
+struct EvServiceFailure : sc::event<EvServiceFailure<TSource, TOrthogonal>>
+{
+  static std::string getEventLabel()
+  {
+    std::string label;
+    EventLabel<TSource>(label);
+    return label;
+  }
+
+  static std::string getDefaultTransitionTag() { return demangledTypeName<ABORT>(); }
+
+  static std::string getDefaultTransitionType() { return demangledTypeName<ABORT>(); }
+};
+
 //---------- CONTROL FLOW EVENTS ----------------------------------------------------------
 
 template <typename StateType>

--- a/smacc2_client_library/lifecyclenode_client/CMakeLists.txt
+++ b/smacc2_client_library/lifecyclenode_client/CMakeLists.txt
@@ -26,6 +26,8 @@ include_directories(include)
 
 add_library(${PROJECT_NAME} SHARED
   src/${PROJECT_NAME}/lifecyclenode_client.cpp
+  src/${PROJECT_NAME}/components/cp_lifecycle_event_monitor.cpp
+  src/${PROJECT_NAME}/components/cp_lifecycle_state_tracker.cpp
 )
 
 ament_target_dependencies(${PROJECT_NAME}

--- a/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/client_behaviors/cb_activate.hpp
+++ b/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/client_behaviors/cb_activate.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <lifecyclenode_client/components/cp_lifecycle_event_monitor.hpp>
 #include <lifecyclenode_client/lifecyclenode_client.hpp>
 #include <smacc2/smacc_asynchronous_client_behavior.hpp>
 
@@ -36,19 +37,18 @@ public:
   {
     smacc2::SmaccAsyncClientBehavior::onStateOrthogonalAllocation<TOrthogonal, TSourceObject>();
 
-    this->requiresClient(this->lifecycleNodeClient_);
+    this->requiresClient(lifecycleNodeClient_);
+    this->requiresComponent(eventMonitor_);
 
-    lifecycleNodeClient_->onTransitionOnActivateSuccess_.connect([this]()
-                                                                 { this->postSuccessEvent(); });
-    lifecycleNodeClient_->onTransitionOnActivateFailure_.connect([this]()
-                                                                 { this->postFailureEvent(); });
-    lifecycleNodeClient_->onTransitionOnActivateError_.connect([this]()
-                                                               { this->postFailureEvent(); });
+    eventMonitor_->onTransitionOnActivateSuccess_.connect([this]() { this->postSuccessEvent(); });
+    eventMonitor_->onTransitionOnActivateFailure_.connect([this]() { this->postFailureEvent(); });
+    eventMonitor_->onTransitionOnActivateError_.connect([this]() { this->postFailureEvent(); });
   }
 
   virtual void onEntry() override { lifecycleNodeClient_->activate(); }
 
 private:
   ClLifecycleNode * lifecycleNodeClient_;
+  CpLifecycleEventMonitor * eventMonitor_;
 };
 }  // namespace cl_lifecyclenode

--- a/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/client_behaviors/cb_cleanup.hpp
+++ b/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/client_behaviors/cb_cleanup.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <lifecyclenode_client/components/cp_lifecycle_event_monitor.hpp>
 #include <lifecyclenode_client/lifecyclenode_client.hpp>
 #include <smacc2/smacc_asynchronous_client_behavior.hpp>
 
@@ -37,18 +38,17 @@ public:
     smacc2::SmaccAsyncClientBehavior::onStateOrthogonalAllocation<TOrthogonal, TSourceObject>();
 
     this->requiresClient(this->lifecycleNodeClient_);
+    this->requiresComponent(eventMonitor_);
 
-    lifecycleNodeClient_->onTransitionOnCleanupSuccess_.connect([this]()
-                                                                { this->postSuccessEvent(); });
-    lifecycleNodeClient_->onTransitionOnCleanupFailure_.connect([this]()
-                                                                { this->postFailureEvent(); });
-    lifecycleNodeClient_->onTransitionOnCleanupError_.connect([this]()
-                                                              { this->postFailureEvent(); });
+    eventMonitor_->onTransitionOnCleanupSuccess_.connect([this]() { this->postSuccessEvent(); });
+    eventMonitor_->onTransitionOnCleanupFailure_.connect([this]() { this->postFailureEvent(); });
+    eventMonitor_->onTransitionOnCleanupError_.connect([this]() { this->postFailureEvent(); });
   }
 
   virtual void onEntry() override { lifecycleNodeClient_->cleanup(); }
 
 private:
   ClLifecycleNode * lifecycleNodeClient_;
+  CpLifecycleEventMonitor * eventMonitor_;
 };
 }  // namespace cl_lifecyclenode

--- a/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/client_behaviors/cb_configure.hpp
+++ b/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/client_behaviors/cb_configure.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <lifecyclenode_client/components/cp_lifecycle_event_monitor.hpp>
 #include <lifecyclenode_client/lifecyclenode_client.hpp>
 #include <smacc2/smacc_asynchronous_client_behavior.hpp>
 
@@ -36,23 +37,23 @@ public:
   {
     smacc2::SmaccAsyncClientBehavior::onStateOrthogonalAllocation<TOrthogonal, TSourceObject>();
 
-    this->requiresClient(this->lifecycleNodeClient_);
+    this->requiresClient(lifecycleNodeClient_);
+    this->requiresComponent(eventMonitor_);
 
-    lifecycleNodeClient_->onTransitionOnConfigureSuccess_.connect(
+    eventMonitor_->onTransitionOnConfigureSuccess_.connect(
       [this]()
       {
         RCLCPP_INFO(getLogger(), "CbConfigure: onTransitionOnConfigureSuccess_");
         this->postSuccessEvent();
       });
-    lifecycleNodeClient_->onTransitionOnConfigureFailure_.connect([this]()
-                                                                  { this->postFailureEvent(); });
-    lifecycleNodeClient_->onTransitionOnConfigureError_.connect([this]()
-                                                                { this->postFailureEvent(); });
+    eventMonitor_->onTransitionOnConfigureFailure_.connect([this]() { this->postFailureEvent(); });
+    eventMonitor_->onTransitionOnConfigureError_.connect([this]() { this->postFailureEvent(); });
   }
 
   virtual void onEntry() override { lifecycleNodeClient_->configure(); }
 
 private:
   ClLifecycleNode * lifecycleNodeClient_;
+  CpLifecycleEventMonitor * eventMonitor_;
 };
 }  // namespace cl_lifecyclenode

--- a/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/client_behaviors/cb_deactivate.hpp
+++ b/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/client_behaviors/cb_deactivate.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <lifecyclenode_client/components/cp_lifecycle_event_monitor.hpp>
 #include <lifecyclenode_client/lifecyclenode_client.hpp>
 #include <smacc2/smacc_asynchronous_client_behavior.hpp>
 
@@ -37,18 +38,17 @@ public:
     smacc2::SmaccAsyncClientBehavior::onStateOrthogonalAllocation<TOrthogonal, TSourceObject>();
 
     this->requiresClient(this->lifecycleNodeClient_);
+    this->requiresComponent(eventMonitor_);
 
-    lifecycleNodeClient_->onTransitionOnDeactivateSuccess_.connect([this]()
-                                                                   { this->postSuccessEvent(); });
-    lifecycleNodeClient_->onTransitionOnDeactivateFailure_.connect([this]()
-                                                                   { this->postFailureEvent(); });
-    lifecycleNodeClient_->onTransitionOnDeactivateError_.connect([this]()
-                                                                 { this->postFailureEvent(); });
+    eventMonitor_->onTransitionOnDeactivateSuccess_.connect([this]() { this->postSuccessEvent(); });
+    eventMonitor_->onTransitionOnDeactivateFailure_.connect([this]() { this->postFailureEvent(); });
+    eventMonitor_->onTransitionOnDeactivateError_.connect([this]() { this->postFailureEvent(); });
   }
 
   virtual void onEntry() override { lifecycleNodeClient_->deactivate(); }
 
 private:
   ClLifecycleNode * lifecycleNodeClient_;
+  CpLifecycleEventMonitor * eventMonitor_;
 };
 }  // namespace cl_lifecyclenode

--- a/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/client_behaviors/cb_deactivate_on_exit.hpp
+++ b/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/client_behaviors/cb_deactivate_on_exit.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <lifecyclenode_client/components/cp_lifecycle_event_monitor.hpp>
 #include <lifecyclenode_client/lifecyclenode_client.hpp>
 #include <smacc2/smacc_asynchronous_client_behavior.hpp>
 
@@ -36,19 +37,18 @@ public:
   {
     smacc2::SmaccAsyncClientBehavior::onStateOrthogonalAllocation<TOrthogonal, TSourceObject>();
 
-    this->requiresClient(this->lifecycleNodeClient_);
+    this->requiresClient(lifecycleNodeClient_);
+    this->requiresComponent(eventMonitor_);
 
-    lifecycleNodeClient_->onTransitionOnDeactivateSuccess_.connect([this]()
-                                                                   { this->postSuccessEvent(); });
-    lifecycleNodeClient_->onTransitionOnDeactivateFailure_.connect([this]()
-                                                                   { this->postFailureEvent(); });
-    lifecycleNodeClient_->onTransitionOnDeactivateError_.connect([this]()
-                                                                 { this->postFailureEvent(); });
+    eventMonitor_->onTransitionOnDeactivateSuccess_.connect([this]() { this->postSuccessEvent(); });
+    eventMonitor_->onTransitionOnDeactivateFailure_.connect([this]() { this->postFailureEvent(); });
+    eventMonitor_->onTransitionOnDeactivateError_.connect([this]() { this->postFailureEvent(); });
   }
 
   virtual void onExit() override { lifecycleNodeClient_->deactivate(); }
 
 private:
   ClLifecycleNode * lifecycleNodeClient_;
+  CpLifecycleEventMonitor * eventMonitor_;
 };
 }  // namespace cl_lifecyclenode

--- a/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/client_behaviors/cb_destroy.hpp
+++ b/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/client_behaviors/cb_destroy.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <lifecyclenode_client/components/cp_lifecycle_event_monitor.hpp>
 #include <lifecyclenode_client/lifecyclenode_client.hpp>
 #include <smacc2/smacc_asynchronous_client_behavior.hpp>
 
@@ -37,18 +38,17 @@ public:
     smacc2::SmaccAsyncClientBehavior::onStateOrthogonalAllocation<TOrthogonal, TSourceObject>();
 
     this->requiresClient(this->lifecycleNodeClient_);
+    this->requiresComponent(eventMonitor_);
 
-    lifecycleNodeClient_->onTransitionOnDestroySuccess_.connect([this]()
-                                                                { this->postSuccessEvent(); });
-    lifecycleNodeClient_->onTransitionOnDestroyFailure_.connect([this]()
-                                                                { this->postFailureEvent(); });
-    lifecycleNodeClient_->onTransitionOnDestroyError_.connect([this]()
-                                                              { this->postFailureEvent(); });
+    eventMonitor_->onTransitionOnDestroySuccess_.connect([this]() { this->postSuccessEvent(); });
+    eventMonitor_->onTransitionOnDestroyFailure_.connect([this]() { this->postFailureEvent(); });
+    eventMonitor_->onTransitionOnDestroyError_.connect([this]() { this->postFailureEvent(); });
   }
 
   virtual void onEntry() override { lifecycleNodeClient_->destroy(); }
 
 private:
   ClLifecycleNode * lifecycleNodeClient_;
+  CpLifecycleEventMonitor * eventMonitor_;
 };
 }  // namespace cl_lifecyclenode

--- a/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/client_behaviors/cb_shutdown.hpp
+++ b/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/client_behaviors/cb_shutdown.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <lifecyclenode_client/components/cp_lifecycle_event_monitor.hpp>
 #include <lifecyclenode_client/lifecyclenode_client.hpp>
 #include <smacc2/smacc_asynchronous_client_behavior.hpp>
 
@@ -37,18 +38,17 @@ public:
     smacc2::SmaccAsyncClientBehavior::onStateOrthogonalAllocation<TOrthogonal, TSourceObject>();
 
     this->requiresClient(this->lifecycleNodeClient_);
+    this->requiresComponent(eventMonitor_);
 
-    lifecycleNodeClient_->onTransitionOnShutdownSuccess_.connect([this]()
-                                                                 { this->postSuccessEvent(); });
-    lifecycleNodeClient_->onTransitionOnShutdownFailure_.connect([this]()
-                                                                 { this->postFailureEvent(); });
-    lifecycleNodeClient_->onTransitionOnShutdownError_.connect([this]()
-                                                               { this->postFailureEvent(); });
+    eventMonitor_->onTransitionOnShutdownSuccess_.connect([this]() { this->postSuccessEvent(); });
+    eventMonitor_->onTransitionOnShutdownFailure_.connect([this]() { this->postFailureEvent(); });
+    eventMonitor_->onTransitionOnShutdownError_.connect([this]() { this->postFailureEvent(); });
   }
 
   virtual void onEntry() override { lifecycleNodeClient_->shutdown(); }
 
 private:
   ClLifecycleNode * lifecycleNodeClient_;
+  CpLifecycleEventMonitor * eventMonitor_;
 };
 }  // namespace cl_lifecyclenode

--- a/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/components.hpp
+++ b/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/components.hpp
@@ -1,0 +1,22 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Core SMACC2 service client component
+#include <smacc2/client_core_components/cp_service_client.hpp>
+
+// Lifecycle-specific components
+#include <lifecyclenode_client/components/cp_lifecycle_event_monitor.hpp>
+#include <lifecyclenode_client/components/cp_lifecycle_state_tracker.hpp>

--- a/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/components/cp_lifecycle_event_monitor.hpp
+++ b/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/components/cp_lifecycle_event_monitor.hpp
@@ -26,7 +26,8 @@
 #include <string>
 
 // Forward declarations
-namespace cl_lifecyclenode {
+namespace cl_lifecyclenode
+{
 class CpLifecycleEventMonitor;
 
 // Event declarations - component is now the source
@@ -80,7 +81,7 @@ template <typename TSourceObject, typename TOrthogonal>
 struct EvTransitionOnErrorSuccess;
 template <typename TSourceObject, typename TOrthogonal>
 struct EvTransitionOnErrorFailure;
-}
+}  // namespace cl_lifecyclenode
 
 namespace cl_lifecyclenode
 {
@@ -184,105 +185,80 @@ public:
     // Set up event posting lambdas with correct template parameters
     // Component is the event source (TSourceObject = CpLifecycleEventMonitor)
 
-    postEventConfigure_ = [this]() {
-      this->postEvent<EvTransitionConfigure<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventConfigure_ = [this]()
+    { this->postEvent<EvTransitionConfigure<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventActivate_ = [this]() {
-      this->postEvent<EvTransitionActivate<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventActivate_ = [this]()
+    { this->postEvent<EvTransitionActivate<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventDeactivate_ = [this]() {
-      this->postEvent<EvTransitionDeactivate<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventDeactivate_ = [this]()
+    { this->postEvent<EvTransitionDeactivate<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventCleanup_ = [this]() {
-      this->postEvent<EvTransitionCleanup<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventCleanup_ = [this]()
+    { this->postEvent<EvTransitionCleanup<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventUnconfiguredShutdown_ = [this]() {
-      this->postEvent<EvTransitionUnconfiguredShutdown<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventUnconfiguredShutdown_ = [this]()
+    { this->postEvent<EvTransitionUnconfiguredShutdown<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventInactiveShutdown_ = [this]() {
-      this->postEvent<EvTransitionInactiveShutdown<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventInactiveShutdown_ = [this]()
+    { this->postEvent<EvTransitionInactiveShutdown<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventActiveShutdown_ = [this]() {
-      this->postEvent<EvTransitionActiveShutdown<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventActiveShutdown_ = [this]()
+    { this->postEvent<EvTransitionActiveShutdown<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventDestroy_ = [this]() {
-      this->postEvent<EvTransitionDestroy<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventDestroy_ = [this]()
+    { this->postEvent<EvTransitionDestroy<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventOnConfigureSuccess_ = [this]() {
-      this->postEvent<EvTransitionOnConfigureSuccess<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventOnConfigureSuccess_ = [this]()
+    { this->postEvent<EvTransitionOnConfigureSuccess<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventOnConfigureFailure_ = [this]() {
-      this->postEvent<EvTransitionOnConfigureFailure<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventOnConfigureFailure_ = [this]()
+    { this->postEvent<EvTransitionOnConfigureFailure<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventOnConfigureError_ = [this]() {
-      this->postEvent<EvTransitionOnConfigureError<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventOnConfigureError_ = [this]()
+    { this->postEvent<EvTransitionOnConfigureError<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventOnActivateSuccess_ = [this]() {
-      this->postEvent<EvTransitionOnActivateSuccess<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventOnActivateSuccess_ = [this]()
+    { this->postEvent<EvTransitionOnActivateSuccess<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventOnActivateFailure_ = [this]() {
-      this->postEvent<EvTransitionOnActivateFailure<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventOnActivateFailure_ = [this]()
+    { this->postEvent<EvTransitionOnActivateFailure<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventOnActivateError_ = [this]() {
-      this->postEvent<EvTransitionOnActivateError<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventOnActivateError_ = [this]()
+    { this->postEvent<EvTransitionOnActivateError<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventOnDeactivateSuccess_ = [this]() {
-      this->postEvent<EvTransitionOnDeactivateSuccess<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventOnDeactivateSuccess_ = [this]()
+    { this->postEvent<EvTransitionOnDeactivateSuccess<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventOnDeactivateFailure_ = [this]() {
-      this->postEvent<EvTransitionOnDeactivateFailure<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventOnDeactivateFailure_ = [this]()
+    { this->postEvent<EvTransitionOnDeactivateFailure<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventOnDeactivateError_ = [this]() {
-      this->postEvent<EvTransitionOnDeactivateError<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventOnDeactivateError_ = [this]()
+    { this->postEvent<EvTransitionOnDeactivateError<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventOnCleanupSuccess_ = [this]() {
-      this->postEvent<EvTransitionOnCleanupSuccess<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventOnCleanupSuccess_ = [this]()
+    { this->postEvent<EvTransitionOnCleanupSuccess<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventOnCleanupFailure_ = [this]() {
-      this->postEvent<EvTransitionOnCleanupFailure<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventOnCleanupFailure_ = [this]()
+    { this->postEvent<EvTransitionOnCleanupFailure<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventOnCleanupError_ = [this]() {
-      this->postEvent<EvTransitionOnCleanupError<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventOnCleanupError_ = [this]()
+    { this->postEvent<EvTransitionOnCleanupError<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventOnShutdownSuccess_ = [this]() {
-      this->postEvent<EvTransitionOnShutdownSuccess<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventOnShutdownSuccess_ = [this]()
+    { this->postEvent<EvTransitionOnShutdownSuccess<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventOnShutdownFailure_ = [this]() {
-      this->postEvent<EvTransitionOnShutdownFailure<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventOnShutdownFailure_ = [this]()
+    { this->postEvent<EvTransitionOnShutdownFailure<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventOnShutdownError_ = [this]() {
-      this->postEvent<EvTransitionOnShutdownError<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventOnShutdownError_ = [this]()
+    { this->postEvent<EvTransitionOnShutdownError<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventOnErrorSuccess_ = [this]() {
-      this->postEvent<EvTransitionOnErrorSuccess<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventOnErrorSuccess_ = [this]()
+    { this->postEvent<EvTransitionOnErrorSuccess<CpLifecycleEventMonitor, TOrthogonal>>(); };
 
-    postEventOnErrorFailure_ = [this]() {
-      this->postEvent<EvTransitionOnErrorFailure<CpLifecycleEventMonitor, TOrthogonal>>();
-    };
+    postEventOnErrorFailure_ = [this]()
+    { this->postEvent<EvTransitionOnErrorFailure<CpLifecycleEventMonitor, TOrthogonal>>(); };
   }
 
 private:

--- a/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/components/cp_lifecycle_event_monitor.hpp
+++ b/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/components/cp_lifecycle_event_monitor.hpp
@@ -1,0 +1,334 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/component.hpp>
+#include <smacc2/smacc_signal.hpp>
+
+#include <lifecycle_msgs/msg/transition_event.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <string>
+
+// Forward declarations
+namespace cl_lifecyclenode {
+class CpLifecycleEventMonitor;
+
+// Event declarations - component is now the source
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionConfigure;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionActivate;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionDeactivate;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionCleanup;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionUnconfiguredShutdown;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionInactiveShutdown;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionActiveShutdown;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionDestroy;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionOnConfigureSuccess;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionOnConfigureFailure;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionOnConfigureError;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionOnActivateSuccess;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionOnActivateFailure;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionOnActivateError;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionOnDeactivateSuccess;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionOnDeactivateFailure;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionOnDeactivateError;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionOnCleanupSuccess;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionOnCleanupFailure;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionOnCleanupError;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionOnShutdownSuccess;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionOnShutdownFailure;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionOnShutdownError;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionOnErrorSuccess;
+template <typename TSourceObject, typename TOrthogonal>
+struct EvTransitionOnErrorFailure;
+}
+
+namespace cl_lifecyclenode
+{
+/**
+ * @brief Component that monitors ROS2 lifecycle node transition events
+ *
+ * CpLifecycleEventMonitor subscribes to lifecycle transition events and parses
+ * them to detect specific transition types. It emits SMACC2 signals for each
+ * transition, enabling event-driven responses to lifecycle state changes.
+ *
+ * This component handles the complex state-pair matching logic required to
+ * distinguish between transition starts, successes, failures, and errors.
+ */
+class CpLifecycleEventMonitor : public smacc2::ISmaccComponent
+{
+public:
+  /**
+   * @brief Constructor with node name
+   * @param nodeName Name of the lifecycle node to monitor
+   */
+  CpLifecycleEventMonitor(std::string nodeName);
+
+  virtual ~CpLifecycleEventMonitor() = default;
+
+  /**
+   * @brief Set the owner client and state machine for this component
+   * @param owner Pointer to the owning client
+   * @param stateMachine Pointer to the state machine
+   */
+  void setOwner(smacc2::ISmaccClient * owner, smacc2::ISmaccStateMachine * stateMachine)
+  {
+    owner_ = owner;
+    stateMachine_ = stateMachine;
+  }
+
+  // SMACC2 Signals for lifecycle transition events
+  // Transition initiation signals
+  smacc2::SmaccSignal<void()> onTransitionCreate_;
+  smacc2::SmaccSignal<void()> onTransitionConfigure_;
+  smacc2::SmaccSignal<void()> onTransitionActivate_;
+  smacc2::SmaccSignal<void()> onTransitionDeactivate_;
+  smacc2::SmaccSignal<void()> onTransitionCleanup_;
+  smacc2::SmaccSignal<void()> onTransitionUnconfiguredShutdown_;
+  smacc2::SmaccSignal<void()> onTransitionInactiveShutdown_;
+  smacc2::SmaccSignal<void()> onTransitionActiveShutdown_;
+  smacc2::SmaccSignal<void()> onTransitionDestroy_;
+
+  // Configure transition result signals
+  smacc2::SmaccSignal<void()> onTransitionOnConfigureSuccess_;
+  smacc2::SmaccSignal<void()> onTransitionOnConfigureFailure_;
+  smacc2::SmaccSignal<void()> onTransitionOnConfigureError_;
+
+  // Activate transition result signals
+  smacc2::SmaccSignal<void()> onTransitionOnActivateSuccess_;
+  smacc2::SmaccSignal<void()> onTransitionOnActivateFailure_;
+  smacc2::SmaccSignal<void()> onTransitionOnActivateError_;
+
+  // Deactivate transition result signals
+  smacc2::SmaccSignal<void()> onTransitionOnDeactivateSuccess_;
+  smacc2::SmaccSignal<void()> onTransitionOnDeactivateFailure_;
+  smacc2::SmaccSignal<void()> onTransitionOnDeactivateError_;
+
+  // Cleanup transition result signals
+  smacc2::SmaccSignal<void()> onTransitionOnCleanupSuccess_;
+  smacc2::SmaccSignal<void()> onTransitionOnCleanupFailure_;
+  smacc2::SmaccSignal<void()> onTransitionOnCleanupError_;
+
+  // Shutdown transition result signals
+  smacc2::SmaccSignal<void()> onTransitionOnShutdownSuccess_;
+  smacc2::SmaccSignal<void()> onTransitionOnShutdownFailure_;
+  smacc2::SmaccSignal<void()> onTransitionOnShutdownError_;
+
+  // Active shutdown specific signals
+  smacc2::SmaccSignal<void()> onTransitionOnActiveShutdownSuccess_;
+  smacc2::SmaccSignal<void()> onTransitionOnActiveShutdownFailure_;
+  smacc2::SmaccSignal<void()> onTransitionOnActiveShutdownError_;
+
+  // Error processing result signals
+  smacc2::SmaccSignal<void()> onTransitionOnErrorSuccess_;
+  smacc2::SmaccSignal<void()> onTransitionOnErrorFailure_;
+  smacc2::SmaccSignal<void()> onTransitionOnErrorError_;
+
+  /**
+   * @brief Get the last received transition event
+   * @return Optional transition event (empty if none received)
+   */
+  std::optional<lifecycle_msgs::msg::TransitionEvent> getLastTransitionEvent() const;
+
+  /**
+   * @brief Component initialization - creates subscription
+   */
+  void onInitialize() override;
+
+  /**
+   * @brief Configure event posting with orthogonal template parameter
+   * This is called from the client's onStateOrthogonalAllocation to set up type-safe event posting
+   */
+  template <typename TOrthogonal, typename TClient>
+  void onStateOrthogonalAllocation()
+  {
+    // Set up event posting lambdas with correct template parameters
+    // Component is the event source (TSourceObject = CpLifecycleEventMonitor)
+
+    postEventConfigure_ = [this]() {
+      this->postEvent<EvTransitionConfigure<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventActivate_ = [this]() {
+      this->postEvent<EvTransitionActivate<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventDeactivate_ = [this]() {
+      this->postEvent<EvTransitionDeactivate<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventCleanup_ = [this]() {
+      this->postEvent<EvTransitionCleanup<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventUnconfiguredShutdown_ = [this]() {
+      this->postEvent<EvTransitionUnconfiguredShutdown<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventInactiveShutdown_ = [this]() {
+      this->postEvent<EvTransitionInactiveShutdown<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventActiveShutdown_ = [this]() {
+      this->postEvent<EvTransitionActiveShutdown<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventDestroy_ = [this]() {
+      this->postEvent<EvTransitionDestroy<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventOnConfigureSuccess_ = [this]() {
+      this->postEvent<EvTransitionOnConfigureSuccess<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventOnConfigureFailure_ = [this]() {
+      this->postEvent<EvTransitionOnConfigureFailure<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventOnConfigureError_ = [this]() {
+      this->postEvent<EvTransitionOnConfigureError<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventOnActivateSuccess_ = [this]() {
+      this->postEvent<EvTransitionOnActivateSuccess<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventOnActivateFailure_ = [this]() {
+      this->postEvent<EvTransitionOnActivateFailure<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventOnActivateError_ = [this]() {
+      this->postEvent<EvTransitionOnActivateError<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventOnDeactivateSuccess_ = [this]() {
+      this->postEvent<EvTransitionOnDeactivateSuccess<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventOnDeactivateFailure_ = [this]() {
+      this->postEvent<EvTransitionOnDeactivateFailure<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventOnDeactivateError_ = [this]() {
+      this->postEvent<EvTransitionOnDeactivateError<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventOnCleanupSuccess_ = [this]() {
+      this->postEvent<EvTransitionOnCleanupSuccess<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventOnCleanupFailure_ = [this]() {
+      this->postEvent<EvTransitionOnCleanupFailure<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventOnCleanupError_ = [this]() {
+      this->postEvent<EvTransitionOnCleanupError<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventOnShutdownSuccess_ = [this]() {
+      this->postEvent<EvTransitionOnShutdownSuccess<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventOnShutdownFailure_ = [this]() {
+      this->postEvent<EvTransitionOnShutdownFailure<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventOnShutdownError_ = [this]() {
+      this->postEvent<EvTransitionOnShutdownError<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventOnErrorSuccess_ = [this]() {
+      this->postEvent<EvTransitionOnErrorSuccess<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+
+    postEventOnErrorFailure_ = [this]() {
+      this->postEvent<EvTransitionOnErrorFailure<CpLifecycleEventMonitor, TOrthogonal>>();
+    };
+  }
+
+private:
+  std::string nodeName_;
+  rclcpp::Subscription<lifecycle_msgs::msg::TransitionEvent>::SharedPtr subscription_;
+  lifecycle_msgs::msg::TransitionEvent::SharedPtr lastTransitionEvent_;
+  mutable std::mutex eventMutex_;
+
+  /**
+   * @brief Callback for transition event subscription
+   * @param msg Transition event message
+   */
+  void onTransitionEvent(const lifecycle_msgs::msg::TransitionEvent::SharedPtr msg);
+
+  // Event posting lambdas - configured via onStateOrthogonalAllocation<TOrthogonal, TClient>()
+  std::function<void()> postEventConfigure_;
+  std::function<void()> postEventActivate_;
+  std::function<void()> postEventDeactivate_;
+  std::function<void()> postEventCleanup_;
+  std::function<void()> postEventUnconfiguredShutdown_;
+  std::function<void()> postEventInactiveShutdown_;
+  std::function<void()> postEventActiveShutdown_;
+  std::function<void()> postEventDestroy_;
+
+  std::function<void()> postEventOnConfigureSuccess_;
+  std::function<void()> postEventOnConfigureFailure_;
+  std::function<void()> postEventOnConfigureError_;
+
+  std::function<void()> postEventOnActivateSuccess_;
+  std::function<void()> postEventOnActivateFailure_;
+  std::function<void()> postEventOnActivateError_;
+
+  std::function<void()> postEventOnDeactivateSuccess_;
+  std::function<void()> postEventOnDeactivateFailure_;
+  std::function<void()> postEventOnDeactivateError_;
+
+  std::function<void()> postEventOnCleanupSuccess_;
+  std::function<void()> postEventOnCleanupFailure_;
+  std::function<void()> postEventOnCleanupError_;
+
+  std::function<void()> postEventOnShutdownSuccess_;
+  std::function<void()> postEventOnShutdownFailure_;
+  std::function<void()> postEventOnShutdownError_;
+
+  std::function<void()> postEventOnErrorSuccess_;
+  std::function<void()> postEventOnErrorFailure_;
+};
+
+}  // namespace cl_lifecyclenode

--- a/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/components/cp_lifecycle_state_tracker.hpp
+++ b/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/components/cp_lifecycle_state_tracker.hpp
@@ -1,0 +1,73 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/component.hpp>
+
+#include <lifecycle_msgs/msg/state.hpp>
+
+#include <mutex>
+#include <optional>
+#include <string>
+
+namespace cl_lifecyclenode
+{
+/**
+ * @brief Component that tracks the current lifecycle state
+ *
+ * CpLifecycleStateTracker maintains knowledge of the current lifecycle node
+ * state, providing thread-safe query methods for state information.
+ */
+class CpLifecycleStateTracker : public smacc2::ISmaccComponent
+{
+public:
+  CpLifecycleStateTracker() = default;
+  virtual ~CpLifecycleStateTracker() = default;
+
+  /**
+   * @brief Update the current state
+   * @param state New lifecycle state
+   */
+  void updateState(const lifecycle_msgs::msg::State & state);
+
+  /**
+   * @brief Get the current lifecycle state
+   * @return Optional state (empty if not yet initialized)
+   */
+  std::optional<lifecycle_msgs::msg::State> getCurrentState() const;
+
+  /**
+   * @brief Get the current state label as string
+   * @return Optional state label (empty if not yet initialized)
+   */
+  std::optional<std::string> getCurrentStateLabel() const;
+
+  /**
+   * @brief Get the current state ID
+   * @return State ID (0 if not yet initialized)
+   */
+  uint8_t getCurrentStateId() const;
+
+  /**
+   * @brief Component initialization
+   */
+  void onInitialize() override;
+
+private:
+  std::optional<lifecycle_msgs::msg::State> currentState_;
+  mutable std::mutex stateMutex_;
+};
+
+}  // namespace cl_lifecyclenode

--- a/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/lifecyclenode_client.hpp
+++ b/smacc2_client_library/lifecyclenode_client/include/lifecyclenode_client/lifecyclenode_client.hpp
@@ -22,6 +22,8 @@
 #include <lifecycle_msgs/msg/transition_event.hpp>
 #include <lifecycle_msgs/srv/change_state.hpp>
 #include <lifecycle_msgs/srv/get_state.hpp>
+#include <lifecyclenode_client/components/cp_lifecycle_event_monitor.hpp>
+#include <smacc2/client_core_components/cp_service_client.hpp>
 #include <smacc2/smacc.hpp>
 #include <smacc2/smacc_client_behavior_base.hpp>
 
@@ -219,268 +221,37 @@ public:
   // @brief execute this method to trigger the destroy transition
   void destroy();
 
-  // @brief execute this method to trigger the create transition
-  virtual void onTransitionEvent(const lifecycle_msgs::msg::TransitionEvent::SharedPtr msg);
-
-  boost::signals2::signal<void(const lifecycle_msgs::msg::TransitionEvent::SharedPtr)>
-    onTransitionEventSignal;
-
-  boost::signals2::signal<void()> onTransitionCreate_;
-  boost::signals2::signal<void()> onTransitionConfigure_;
-  boost::signals2::signal<void()> onTransitionCleanup_;
-  boost::signals2::signal<void()> onTransitionActivate_;
-  boost::signals2::signal<void()> onTransitionDeactivate_;
-
-  boost::signals2::signal<void()> onTransitionUnconfiguredShutdown_;
-  boost::signals2::signal<void()> onTransitionInactiveShutdown_;
-  boost::signals2::signal<void()> onTransitionActiveShutdown_;
-
-  boost::signals2::signal<void()> onTransitionDestroy_;
-
-  boost::signals2::signal<void()> onTransitionOnConfigureSuccess_;
-  boost::signals2::signal<void()> onTransitionOnConfigureFailure_;
-  boost::signals2::signal<void()> onTransitionOnConfigureError_;
-
-  boost::signals2::signal<void()> onTransitionOnActivateSuccess_;
-  boost::signals2::signal<void()> onTransitionOnActivateFailure_;
-  boost::signals2::signal<void()> onTransitionOnActivateError_;
-
-  boost::signals2::signal<void()> onTransitionOnDeactivateSuccess_;
-  boost::signals2::signal<void()> onTransitionOnDeactivateFailure_;
-  boost::signals2::signal<void()> onTransitionOnDeactivateError_;
-
-  boost::signals2::signal<void()> onTransitionOnCleanupSuccess_;
-  boost::signals2::signal<void()> onTransitionOnCleanupFailure_;
-  boost::signals2::signal<void()> onTransitionOnCleanupError_;
-
-  boost::signals2::signal<void()> onTransitionOnShutdownSuccess_;
-  boost::signals2::signal<void()> onTransitionOnShutdownFailure_;
-  boost::signals2::signal<void()> onTransitionOnShutdownError_;
-
-  boost::signals2::signal<void()> onTransitionOnActiveShutdownSuccess_;
-  boost::signals2::signal<void()> onTransitionOnActiveShutdownFailure_;
-  boost::signals2::signal<void()> onTransitionOnActiveShutdownError_;
-
-  boost::signals2::signal<void()> onTransitionOnErrorSuccess_;
-  boost::signals2::signal<void()> onTransitionOnErrorFailure_;
-  boost::signals2::signal<void()> onTransitionOnErrorError_;
-
+  /**
+   * @brief Configure component for event posting during orthogonal allocation
+   */
   template <typename TOrthogonal, typename TSourceObject>
   void onStateOrthogonalAllocation()
   {
-    this->postOnTransitionCreate_ = [=]()
+    // Create and register component with orthogonal
+    if (!eventMonitor_)
     {
-      RCLCPP_INFO(this->getLogger(), "postOnTransitionCreate_");
-      this->onTransitionCreate_();
-      sc::event<EvTransitionCreate<TSourceObject, TOrthogonal>> * ev =
-        new EvTransitionCreate<TSourceObject, TOrthogonal>();
-      this->postEvent(ev);
-    };
+      eventMonitor_ =
+        this->template createComponent<CpLifecycleEventMonitor, TOrthogonal, ClLifecycleNode>(
+          nodeName_);
+    }
 
-    this->postOnTransitionConfigure_ = [=]()
-    {
-      this->onTransitionConfigure_();
-      this->postEvent<EvTransitionConfigure<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionActivate_ = [=]()
-    {
-      this->onTransitionActivate_();
-      this->postEvent<EvTransitionActivate<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionDeactivate_ = [=]()
-    {
-      this->onTransitionDeactivate_();
-      this->postEvent<EvTransitionDeactivate<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionUnconfiguredShutdown_ = [=]()
-    {
-      this->onTransitionUnconfiguredShutdown_();
-      this->postEvent<EvTransitionUnconfiguredShutdown<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionInactiveShutdown_ = [=]()
-    {
-      this->onTransitionInactiveShutdown_();
-      this->postEvent<EvTransitionInactiveShutdown<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionActiveShutdown_ = [=]()
-    {
-      this->onTransitionActiveShutdown_();
-      this->postEvent<EvTransitionActiveShutdown<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionDestroy_ = [=]()
-    {
-      this->onTransitionDestroy_();
-      this->postEvent<EvTransitionDestroy<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnConfigureSuccess_ = [=]()
-    {
-      this->onTransitionOnConfigureSuccess_();
-      this->postEvent<EvTransitionOnConfigureSuccess<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnConfigureFailure_ = [=]()
-    {
-      this->onTransitionOnConfigureFailure_();
-      this->postEvent<EvTransitionOnConfigureFailure<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnConfigureError_ = [=]()
-    {
-      this->onTransitionOnConfigureError_();
-      this->postEvent<EvTransitionOnConfigureError<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnActivateSuccess_ = [=]()
-    {
-      this->onTransitionOnActivateSuccess_();
-      this->postEvent<EvTransitionOnActivateSuccess<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnActivateFailure_ = [=]()
-    {
-      this->onTransitionOnActivateFailure_();
-      this->postEvent<EvTransitionOnActivateFailure<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnActivateError_ = [=]()
-    {
-      this->onTransitionOnActivateError_();
-      this->postEvent<EvTransitionOnActivateError<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnDeactivateSuccess_ = [=]()
-    {
-      this->onTransitionOnDeactivateSuccess_();
-      this->postEvent<EvTransitionOnDeactivateSuccess<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnDeactivateFailure_ = [=]()
-    {
-      this->onTransitionOnDeactivateFailure_();
-      this->postEvent<EvTransitionOnDeactivateFailure<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnDeactivateError_ = [=]()
-    {
-      this->onTransitionOnDeactivateError_();
-      this->postEvent<EvTransitionOnDeactivateError<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionCleanup_ = [=]()
-    {
-      this->onTransitionCleanup_();
-      this->postEvent<EvTransitionCleanup<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnCleanupSuccess_ = [=]()
-    {
-      this->onTransitionOnCleanupSuccess_();
-      this->postEvent<EvTransitionOnCleanupSuccess<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnCleanupFailure_ = [=]()
-    {
-      this->onTransitionOnCleanupFailure_();
-      this->postEvent<EvTransitionOnCleanupFailure<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnCleanupError_ = [=]()
-    {
-      this->onTransitionOnCleanupError_();
-      this->postEvent<EvTransitionOnCleanupError<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnShutdownSuccess_ = [=]()
-    {
-      this->onTransitionOnShutdownSuccess_();
-      this->postEvent<EvTransitionOnShutdownSuccess<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnShutdownFailure_ = [=]()
-    {
-      this->onTransitionOnShutdownFailure_();
-      this->postEvent<EvTransitionOnShutdownFailure<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnShutdownError_ = [=]()
-    {
-      this->onTransitionOnShutdownError_();
-      this->postEvent<EvTransitionOnShutdownError<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnErrorSuccess_ = [=]()
-    {
-      this->onTransitionOnErrorSuccess_();
-      this->postEvent<EvTransitionOnErrorSuccess<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnErrorFailure_ = [=]()
-    {
-      this->onTransitionOnErrorFailure_();
-      this->postEvent<EvTransitionOnErrorFailure<TSourceObject, TOrthogonal>>();
-    };
-
-    this->postOnTransitionOnErrorError_ = [=]()
-    {
-      this->onTransitionOnErrorError_();
-      this->postEvent<EvTransitionOnErrorError<TSourceObject, TOrthogonal>>();
-    };
+    // Configure component for this orthogonal
+    eventMonitor_->template onStateOrthogonalAllocation<TOrthogonal, ClLifecycleNode>();
   }
 
 private:
+  // Phase 2: Service clients (will be migrated to CpServiceClient components in future enhancement)
   rclcpp::Client<lifecycle_msgs::srv::GetState>::SharedPtr client_get_state_;
   rclcpp::Client<lifecycle_msgs::srv::ChangeState>::SharedPtr client_change_state_;
 
-  rclcpp::Subscription<lifecycle_msgs::msg::TransitionEvent>::SharedPtr
-    subscription_transition_event_;
+  // Phase 3: Event monitor component
+  CpLifecycleEventMonitor * eventMonitor_;
 
   std::string nodeName_;
   const std::string node_get_state_topic = "/get_state";
   const std::string node_change_state_topic = "/change_state";
-  const std::string node_transition_event_topic = "/transition_event";
 
   lifecycle_msgs::msg::TransitionEvent::SharedPtr lastTransitionEvent_;
-
-  std::function<void()> postOnTransitionCreate_;
-  std::function<void()> postOnTransitionConfigure_;
-  std::function<void()> postOnTransitionCleanup_;
-  std::function<void()> postOnTransitionActivate_;
-  std::function<void()> postOnTransitionDeactivate_;
-  std::function<void()> postOnTransitionUnconfiguredShutdown_;
-  std::function<void()> postOnTransitionInactiveShutdown_;
-  std::function<void()> postOnTransitionActiveShutdown_;
-  std::function<void()> postOnTransitionDestroy_;
-
-  std::function<void()> postOnTransitionOnConfigureSuccess_;
-  std::function<void()> postOnTransitionOnConfigureFailure_;
-  std::function<void()> postOnTransitionOnConfigureError_;
-
-  std::function<void()> postOnTransitionOnActivateSuccess_;
-  std::function<void()> postOnTransitionOnActivateFailure_;
-  std::function<void()> postOnTransitionOnActivateError_;
-
-  std::function<void()> postOnTransitionOnDeactivateSuccess_;
-  std::function<void()> postOnTransitionOnDeactivateFailure_;
-  std::function<void()> postOnTransitionOnDeactivateError_;
-
-  std::function<void()> postOnTransitionOnCleanupSuccess_;
-  std::function<void()> postOnTransitionOnCleanupFailure_;
-  std::function<void()> postOnTransitionOnCleanupError_;
-
-  std::function<void()> postOnTransitionOnShutdownSuccess_;
-  std::function<void()> postOnTransitionOnShutdownFailure_;
-  std::function<void()> postOnTransitionOnShutdownError_;
-
-  std::function<void()> postOnTransitionOnErrorSuccess_;
-  std::function<void()> postOnTransitionOnErrorFailure_;
-  std::function<void()> postOnTransitionOnErrorError_;
 };
 
 }  // namespace cl_lifecyclenode

--- a/smacc2_client_library/lifecyclenode_client/src/lifecyclenode_client/components/cp_lifecycle_event_monitor.cpp
+++ b/smacc2_client_library/lifecyclenode_client/src/lifecyclenode_client/components/cp_lifecycle_event_monitor.cpp
@@ -16,28 +16,24 @@
 
 namespace cl_lifecyclenode
 {
-CpLifecycleEventMonitor::CpLifecycleEventMonitor(std::string nodeName)
-: nodeName_(nodeName)
-{
-}
+CpLifecycleEventMonitor::CpLifecycleEventMonitor(std::string nodeName) : nodeName_(nodeName) {}
 
 void CpLifecycleEventMonitor::onInitialize()
 {
   // Phase 3: Create subscription to lifecycle transition events
   const std::string node_transition_event_topic = "/transition_event";
 
-  subscription_ =
-    getNode()->create_subscription<lifecycle_msgs::msg::TransitionEvent>(
-      nodeName_ + node_transition_event_topic, 100,
-      std::bind(&CpLifecycleEventMonitor::onTransitionEvent, this, std::placeholders::_1));
+  subscription_ = getNode()->create_subscription<lifecycle_msgs::msg::TransitionEvent>(
+    nodeName_ + node_transition_event_topic, 100,
+    std::bind(&CpLifecycleEventMonitor::onTransitionEvent, this, std::placeholders::_1));
 
   RCLCPP_INFO(
     getLogger(), "[CpLifecycleEventMonitor] Subscribed to: %s",
     (nodeName_ + node_transition_event_topic).c_str());
 }
 
-std::optional<lifecycle_msgs::msg::TransitionEvent> CpLifecycleEventMonitor::
-  getLastTransitionEvent() const
+std::optional<lifecycle_msgs::msg::TransitionEvent>
+CpLifecycleEventMonitor::getLastTransitionEvent() const
 {
   std::lock_guard<std::mutex> lock(eventMutex_);
   if (lastTransitionEvent_)
@@ -51,8 +47,8 @@ void CpLifecycleEventMonitor::onTransitionEvent(
   const lifecycle_msgs::msg::TransitionEvent::SharedPtr msg)
 {
   RCLCPP_INFO(
-    getLogger(), "[CpLifecycleEventMonitor] Transition event: %d -> %d",
-    msg->start_state.id, msg->goal_state.id);
+    getLogger(), "[CpLifecycleEventMonitor] Transition event: %d -> %d", msg->start_state.id,
+    msg->goal_state.id);
 
   // Store the event
   {

--- a/smacc2_client_library/lifecyclenode_client/src/lifecyclenode_client/components/cp_lifecycle_event_monitor.cpp
+++ b/smacc2_client_library/lifecyclenode_client/src/lifecyclenode_client/components/cp_lifecycle_event_monitor.cpp
@@ -1,0 +1,269 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <lifecyclenode_client/components/cp_lifecycle_event_monitor.hpp>
+
+namespace cl_lifecyclenode
+{
+CpLifecycleEventMonitor::CpLifecycleEventMonitor(std::string nodeName)
+: nodeName_(nodeName)
+{
+}
+
+void CpLifecycleEventMonitor::onInitialize()
+{
+  // Phase 3: Create subscription to lifecycle transition events
+  const std::string node_transition_event_topic = "/transition_event";
+
+  subscription_ =
+    getNode()->create_subscription<lifecycle_msgs::msg::TransitionEvent>(
+      nodeName_ + node_transition_event_topic, 100,
+      std::bind(&CpLifecycleEventMonitor::onTransitionEvent, this, std::placeholders::_1));
+
+  RCLCPP_INFO(
+    getLogger(), "[CpLifecycleEventMonitor] Subscribed to: %s",
+    (nodeName_ + node_transition_event_topic).c_str());
+}
+
+std::optional<lifecycle_msgs::msg::TransitionEvent> CpLifecycleEventMonitor::
+  getLastTransitionEvent() const
+{
+  std::lock_guard<std::mutex> lock(eventMutex_);
+  if (lastTransitionEvent_)
+  {
+    return *lastTransitionEvent_;
+  }
+  return std::nullopt;
+}
+
+void CpLifecycleEventMonitor::onTransitionEvent(
+  const lifecycle_msgs::msg::TransitionEvent::SharedPtr msg)
+{
+  RCLCPP_INFO(
+    getLogger(), "[CpLifecycleEventMonitor] Transition event: %d -> %d",
+    msg->start_state.id, msg->goal_state.id);
+
+  // Store the event
+  {
+    std::lock_guard<std::mutex> lock(eventMutex_);
+    lastTransitionEvent_ = msg;
+  }
+
+  // Phase 3: Full state-pair matching logic (moved from ClLifecycleNode)
+  // Parse transition events and emit corresponding signals
+
+  // TRANSITION_CONFIGURE
+  if (
+    msg->start_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_CONFIGURE");
+    onTransitionConfigure_();
+    if (postEventConfigure_) postEventConfigure_();
+  }
+  // TRANSITION_CLEANUP
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_CLEANUP");
+    onTransitionCleanup_();
+    if (postEventCleanup_) postEventCleanup_();
+  }
+  // TRANSITION_ACTIVATE
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_ACTIVATE");
+    onTransitionActivate_();
+    if (postEventActivate_) postEventActivate_();
+  }
+  // TRANSITION_DEACTIVATE
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_DEACTIVATING)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_DEACTIVATE");
+    onTransitionDeactivate_();
+    if (postEventDeactivate_) postEventDeactivate_();
+  }
+  // TRANSITION_UNCONFIGURED_SHUTDOWN
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_UNCONFIGURED_SHUTDOWN");
+    onTransitionUnconfiguredShutdown_();
+    if (postEventUnconfiguredShutdown_) postEventUnconfiguredShutdown_();
+  }
+  // TRANSITION_INACTIVE_SHUTDOWN
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_INACTIVE_SHUTDOWN");
+    onTransitionInactiveShutdown_();
+    if (postEventInactiveShutdown_) postEventInactiveShutdown_();
+  }
+  // TRANSITION_ACTIVE_SHUTDOWN
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_ACTIVE_SHUTDOWN");
+    onTransitionActiveShutdown_();
+    if (postEventActiveShutdown_) postEventActiveShutdown_();
+  }
+  // TRANSITION_DESTROY
+  else if (msg->start_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_DESTROY");
+    onTransitionDestroy_();
+    if (postEventDestroy_) postEventDestroy_();
+  }
+  // TRANSITION_ON_CONFIGURE_SUCCESS
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_ON_CONFIGURE_SUCCESS");
+    onTransitionOnConfigureSuccess_();
+    if (postEventOnConfigureSuccess_) postEventOnConfigureSuccess_();
+  }
+  // TRANSITION_ON_CONFIGURE_FAILURE
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_ON_CONFIGURE_FAILURE");
+    onTransitionOnConfigureFailure_();
+    if (postEventOnConfigureFailure_) postEventOnConfigureFailure_();
+  }
+  // TRANSITION_ON_CONFIGURE_ERROR
+  if (
+    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_ON_CONFIGURE_ERROR");
+    onTransitionOnConfigureError_();
+    if (postEventOnConfigureError_) postEventOnConfigureError_();
+  }
+  // TRANSITION_ON_CLEANUP_SUCCESS
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_ON_CLEANUP_SUCCESS");
+    onTransitionOnCleanupSuccess_();
+    if (postEventOnCleanupSuccess_) postEventOnCleanupSuccess_();
+  }
+  // TRANSITION_ON_CLEANUP_ERROR
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_ON_CLEANUP_ERROR");
+    onTransitionOnCleanupError_();
+    if (postEventOnCleanupError_) postEventOnCleanupError_();
+  }
+  // TRANSITION_ON_ACTIVATE_SUCCESS
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_ON_ACTIVATE_SUCCESS");
+    onTransitionOnActivateSuccess_();
+    if (postEventOnActivateSuccess_) postEventOnActivateSuccess_();
+  }
+  // TRANSITION_ON_ACTIVATE_FAILURE
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_ON_ACTIVATE_FAILURE");
+    onTransitionOnActivateFailure_();
+    if (postEventOnActivateFailure_) postEventOnActivateFailure_();
+  }
+  // TRANSITION_ON_ACTIVATE_ERROR
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_ON_ACTIVATE_ERROR");
+    onTransitionOnActivateError_();
+    if (postEventOnActivateError_) postEventOnActivateError_();
+  }
+  // TRANSITION_ON_DEACTIVATE_SUCCESS
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_DEACTIVATING &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_ON_DEACTIVATE_SUCCESS");
+    onTransitionOnDeactivateSuccess_();
+    if (postEventOnDeactivateSuccess_) postEventOnDeactivateSuccess_();
+  }
+  // TRANSITION_ON_DEACTIVATE_ERROR
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_DEACTIVATING &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_ON_DEACTIVATE_ERROR");
+    onTransitionOnDeactivateError_();
+    if (postEventOnDeactivateError_) postEventOnDeactivateError_();
+  }
+  // TRANSITION_ON_SHUTDOWN_SUCCESS
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_ON_SHUTDOWN_SUCCESS");
+    onTransitionOnShutdownSuccess_();
+    if (postEventOnShutdownSuccess_) postEventOnShutdownSuccess_();
+  }
+  // TRANSITION_ON_SHUTDOWN_ERROR
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_ON_SHUTDOWN_ERROR");
+    onTransitionOnShutdownError_();
+    if (postEventOnShutdownError_) postEventOnShutdownError_();
+  }
+  // TRANSITION_ON_ERROR_SUCCESS
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_ON_ERROR_SUCCESS");
+    onTransitionOnErrorSuccess_();
+    if (postEventOnErrorSuccess_) postEventOnErrorSuccess_();
+  }
+  // TRANSITION_ON_ERROR_FAILURE
+  else if (
+    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING &&
+    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_ON_ERROR_FAILURE");
+    onTransitionOnErrorFailure_();
+    if (postEventOnErrorFailure_) postEventOnErrorFailure_();
+  }
+  // UNKNOWN TRANSITION
+  else
+  {
+    RCLCPP_INFO(getLogger(), "TRANSITION_UNKNOWN");
+  }
+}
+
+}  // namespace cl_lifecyclenode

--- a/smacc2_client_library/lifecyclenode_client/src/lifecyclenode_client/components/cp_lifecycle_state_tracker.cpp
+++ b/smacc2_client_library/lifecyclenode_client/src/lifecyclenode_client/components/cp_lifecycle_state_tracker.cpp
@@ -1,0 +1,60 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <lifecyclenode_client/components/cp_lifecycle_state_tracker.hpp>
+
+namespace cl_lifecyclenode
+{
+void CpLifecycleStateTracker::onInitialize()
+{
+  // Initialize with empty state
+  RCLCPP_INFO(getLogger(), "[CpLifecycleStateTracker] Component initialized");
+}
+
+void CpLifecycleStateTracker::updateState(const lifecycle_msgs::msg::State & state)
+{
+  std::lock_guard<std::mutex> lock(stateMutex_);
+  currentState_ = state;
+  RCLCPP_DEBUG(
+    getLogger(), "[CpLifecycleStateTracker] State updated to: %s (id: %d)", state.label.c_str(),
+    state.id);
+}
+
+std::optional<lifecycle_msgs::msg::State> CpLifecycleStateTracker::getCurrentState() const
+{
+  std::lock_guard<std::mutex> lock(stateMutex_);
+  return currentState_;
+}
+
+std::optional<std::string> CpLifecycleStateTracker::getCurrentStateLabel() const
+{
+  std::lock_guard<std::mutex> lock(stateMutex_);
+  if (currentState_)
+  {
+    return currentState_->label;
+  }
+  return std::nullopt;
+}
+
+uint8_t CpLifecycleStateTracker::getCurrentStateId() const
+{
+  std::lock_guard<std::mutex> lock(stateMutex_);
+  if (currentState_)
+  {
+    return currentState_->id;
+  }
+  return 0;
+}
+
+}  // namespace cl_lifecyclenode

--- a/smacc2_client_library/lifecyclenode_client/src/lifecyclenode_client/lifecyclenode_client.cpp
+++ b/smacc2_client_library/lifecyclenode_client/src/lifecyclenode_client/lifecyclenode_client.cpp
@@ -17,26 +17,26 @@
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/
+#include <lifecyclenode_client/components/cp_lifecycle_event_monitor.hpp>
 #include <lifecyclenode_client/lifecyclenode_client.hpp>
 #include <string>
 
 namespace cl_lifecyclenode
 {
-ClLifecycleNode::ClLifecycleNode(std::string node_name) : nodeName_(node_name) {}
+ClLifecycleNode::ClLifecycleNode(std::string node_name)
+: nodeName_(node_name), eventMonitor_(nullptr)
+{
+}
 
 ClLifecycleNode::~ClLifecycleNode() {}
 
 void ClLifecycleNode::onInitialize()
 {
+  // Create service clients
   client_get_state_ = this->getNode()->create_client<lifecycle_msgs::srv::GetState>(
     this->nodeName_ + node_get_state_topic);
   client_change_state_ = this->getNode()->create_client<lifecycle_msgs::srv::ChangeState>(
     this->nodeName_ + node_change_state_topic);
-
-  this->subscription_transition_event_ =
-    this->getNode() /*  */->create_subscription<lifecycle_msgs::msg::TransitionEvent>(
-      this->nodeName_ + node_transition_event_topic, 100,
-      std::bind(&ClLifecycleNode::onTransitionEvent, this, std::placeholders::_1));
 }
 
 void ClLifecycleNode::changeState(uint8_t state)
@@ -72,237 +72,4 @@ void ClLifecycleNode::shutdown()
   changeState(lifecycle_msgs::msg::Transition::TRANSITION_UNCONFIGURED_SHUTDOWN);
 }
 
-void ClLifecycleNode::onTransitionEvent(const lifecycle_msgs::msg::TransitionEvent::SharedPtr msg)
-{
-  RCLCPP_INFO(
-    this->getNode()->get_logger(), "[ClLifecycleNode] Transition event received: %d -> %d",
-    msg->start_state.id, msg->goal_state.id);
-
-  lastTransitionEvent_ = msg;
-  // switch (msg->transition.id)
-  // {
-  // case lifecycle_msgs::msg::Transition::TRANSITION_CREATE:
-  // if (msg->start_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN &&
-  //     msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
-  // {
-  //   RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_CREATE");
-  //   this->postOnTransitionCreate_();
-  // }
-  // // case lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE:
-  // else
-  if (
-    msg->start_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_CONFIGURE");
-    this->postOnTransitionConfigure_();
-  }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_CLEANUP");
-    this->postOnTransitionCleanup_();
-  }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ACTIVATE");
-    this->postOnTransitionActivate_();
-  }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_DEACTIVATING)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_DEACTIVATE");
-    this->postOnTransitionDeactivate_();
-  }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_UNCONFIGURED_SHUTDOWN:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_UNCONFIGURED_SHUTDOWN");
-    this->postOnTransitionUnconfiguredShutdown_();
-  }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_INACTIVE_SHUTDOWN");
-    this->postOnTransitionInactiveShutdown_();
-  }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ACTIVE_SHUTDOWN:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ACTIVE_SHUTDOWN");
-    this->postOnTransitionActiveShutdown_();
-  }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_DESTROY:
-  else if (msg->start_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)
-  // &&msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_DESTROYING
-
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_DESTROY");
-    this->postOnTransitionDestroy_();
-  }
-
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_CONFIGURE_SUCCESS:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_CONFIGURE_SUCCESS");
-    this->postOnTransitionOnConfigureSuccess_();
-  }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_CONFIGURE_FAILURE:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_CONFIGURE_FAILURE");
-    this->postOnTransitionOnConfigureFailure_();
-  }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_CONFIGURE_ERROR:
-  if (
-    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_CONFIGURE_ERROR");
-    this->postOnTransitionOnConfigureError_();
-  }
-
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_CLEANUP_SUCCESS:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_CLEANUP_SUCCESS");
-    this->postOnTransitionOnCleanupSuccess_();
-  }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_CLEANUP_FAILURE:
-  // else if (msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP
-  // &&msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING)
-  // {
-  //   RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_CLEANUP_FAILURE");
-  //   this->postOnTransitionOnCleanupFailure_();
-  // }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_CLEANUP_ERROR:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_CLEANUP_ERROR");
-    this->postOnTransitionOnCleanupError_();
-  }
-
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_ACTIVATE_SUCCESS:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_ACTIVATE_SUCCESS");
-    this->postOnTransitionOnActivateSuccess_();
-  }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_ACTIVATE_FAILURE:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_ACTIVATE_FAILURE");
-    this->postOnTransitionOnActivateFailure_();
-  }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_ACTIVATE_ERROR:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_ACTIVATE_ERROR");
-    this->postOnTransitionOnActivateError_();
-  }
-
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_DEACTIVATE_SUCCESS:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_DEACTIVATING &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_DEACTIVATE_SUCCESS");
-    this->postOnTransitionOnDeactivateSuccess_();
-  }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_DEACTIVATE_FAILURE:
-  // else if (msg->start_state.id == &&msg->goal_state.id ==)
-  // {
-  //   RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_DEACTIVATE_FAILURE");
-  //   this->postOnTransitionOnDeactivateFailure_();
-  // }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_DEACTIVATE_ERROR:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_DEACTIVATING &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_DEACTIVATE_ERROR");
-    this->postOnTransitionOnDeactivateError_();
-  }
-
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_SHUTDOWN_SUCCESS:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_SHUTDOWN_SUCCESS");
-    this->postOnTransitionOnShutdownSuccess_();
-  }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_SHUTDOWN_FAILURE:
-  // else if (msg->start_state.id == &&msg->goal_state.id ==)
-  // {
-  //   RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_SHUTDOWN_FAILURE");
-  //   this->postOnTransitionOnShutdownFailure_();
-  // }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_SHUTDOWN_ERROR:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_SHUTDOWN_ERROR");
-    this->postOnTransitionOnShutdownError_();
-  }
-
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_ERROR_SUCCESS:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_ERROR_SUCCESS");
-    this->postOnTransitionOnErrorSuccess_();
-  }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_ERROR_FAILURE:
-  else if (
-    msg->start_state.id == lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING &&
-    msg->goal_state.id == lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_ERROR_FAILURE");
-    this->postOnTransitionOnErrorFailure_();
-  }
-  // case lifecycle_msgs::msg::Transition::TRANSITION_ON_ERROR_ERROR:
-  // else if (msg->start_state.id == &&msg->goal_state.id ==)
-  // {
-  //   RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_ON_ERROR_ERROR");
-  //   this->postOnTransitionOnErrorError_();
-  // }
-
-  // default:
-  else
-  {
-    RCLCPP_INFO(this->getNode()->get_logger(), "TRANSITION_UNKNOWN");
-  }
-  // }
-
-}  // namespace cl_lifecyclenode
 }  // namespace cl_lifecyclenode

--- a/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_activating.hpp
+++ b/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_activating.hpp
@@ -32,9 +32,9 @@ struct StActivating : smacc2::SmaccState<StActivating, SmAtomicLifecycle>
 
   // TRANSITION TABLE
   typedef mpl::list<
-          Transition<EvTransitionOnActivateSuccess<ClLifecycleNode, OrLifecycleNode>, StActive, SUCCESS>,
-          Transition<EvTransitionOnActivateFailure<ClLifecycleNode, OrLifecycleNode>, StInactive, ABORT>,
-          Transition<EvTransitionOnActivateError<ClLifecycleNode, OrLifecycleNode>, StErrorProcessing, ABORT>
+          Transition<EvTransitionOnActivateSuccess<CpLifecycleEventMonitor, OrLifecycleNode>, StActive, SUCCESS>,
+          Transition<EvTransitionOnActivateFailure<CpLifecycleEventMonitor, OrLifecycleNode>, StInactive, ABORT>,
+          Transition<EvTransitionOnActivateError<CpLifecycleEventMonitor, OrLifecycleNode>, StErrorProcessing, ABORT>
       >
       reactions;
 

--- a/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_active.hpp
+++ b/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_active.hpp
@@ -32,8 +32,8 @@ struct StActive : smacc2::SmaccState<StActive, SmAtomicLifecycle>
 
   // TRANSITION TABLE
   typedef mpl::list<
-          Transition<EvTransitionDeactivate<ClLifecycleNode, OrLifecycleNode>, StDeactivating, SUCCESS>,
-          Transition<EvTransitionActiveShutdown<ClLifecycleNode, OrLifecycleNode>, StShuttingDown, SUCCESS>
+          Transition<EvTransitionDeactivate<CpLifecycleEventMonitor, OrLifecycleNode>, StDeactivating, SUCCESS>,
+          Transition<EvTransitionActiveShutdown<CpLifecycleEventMonitor, OrLifecycleNode>, StShuttingDown, SUCCESS>
 
       >
       reactions;

--- a/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_cleaning_up.hpp
+++ b/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_cleaning_up.hpp
@@ -32,8 +32,8 @@ struct StCleaningUp : smacc2::SmaccState<StCleaningUp, SmAtomicLifecycle>
 
   // TRANSITION TABLE
   typedef mpl::list<
-          Transition<EvTransitionOnCleanupSuccess<ClLifecycleNode, OrLifecycleNode>, StUnconfigured, SUCCESS>,
-          Transition<EvTransitionOnCleanupError<ClLifecycleNode, OrLifecycleNode>, StErrorProcessing, ABORT>
+          Transition<EvTransitionOnCleanupSuccess<CpLifecycleEventMonitor, OrLifecycleNode>, StUnconfigured, SUCCESS>,
+          Transition<EvTransitionOnCleanupError<CpLifecycleEventMonitor, OrLifecycleNode>, StErrorProcessing, ABORT>
       >
       reactions;
 

--- a/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_configuring.hpp
+++ b/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_configuring.hpp
@@ -32,9 +32,9 @@ struct StConfiguring : smacc2::SmaccState<StConfiguring, SmAtomicLifecycle>
 
   // TRANSITION TABLE
   typedef mpl::list<
-          Transition<EvTransitionOnConfigureSuccess<ClLifecycleNode, OrLifecycleNode>, StInactive, SUCCESS>,
-          Transition<EvTransitionOnConfigureFailure<ClLifecycleNode, OrLifecycleNode>, StUnconfigured, ABORT> ,
-          Transition<EvTransitionOnConfigureError<ClLifecycleNode, OrLifecycleNode>, StErrorProcessing, ABORT>
+          Transition<EvTransitionOnConfigureSuccess<CpLifecycleEventMonitor, OrLifecycleNode>, StInactive, SUCCESS>,
+          Transition<EvTransitionOnConfigureFailure<CpLifecycleEventMonitor, OrLifecycleNode>, StUnconfigured, ABORT> ,
+          Transition<EvTransitionOnConfigureError<CpLifecycleEventMonitor, OrLifecycleNode>, StErrorProcessing, ABORT>
         >
       reactions;
 

--- a/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_deactivating.hpp
+++ b/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_deactivating.hpp
@@ -32,8 +32,8 @@ struct StDeactivating : smacc2::SmaccState<StDeactivating, SmAtomicLifecycle>
 
   // TRANSITION TABLE
   typedef mpl::list<
-          Transition<EvTransitionOnDeactivateSuccess<ClLifecycleNode, OrLifecycleNode>, StInactive, SUCCESS>,
-          Transition<EvTransitionOnDeactivateError<ClLifecycleNode, OrLifecycleNode>, StErrorProcessing, ABORT>
+          Transition<EvTransitionOnDeactivateSuccess<CpLifecycleEventMonitor, OrLifecycleNode>, StInactive, SUCCESS>,
+          Transition<EvTransitionOnDeactivateError<CpLifecycleEventMonitor, OrLifecycleNode>, StErrorProcessing, ABORT>
       >
       reactions;
 

--- a/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_error_processing.hpp
+++ b/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_error_processing.hpp
@@ -32,8 +32,8 @@ struct StErrorProcessing : smacc2::SmaccState<StErrorProcessing, SmAtomicLifecyc
 
   // TRANSITION TABLE
   typedef mpl::list<
-        Transition<EvTransitionOnErrorSuccess<ClLifecycleNode, OrLifecycleNode>, StUnconfigured, SUCCESS>,
-        Transition<EvTransitionOnErrorFailure<ClLifecycleNode, OrLifecycleNode>, StFinalized, ABORT>
+        Transition<EvTransitionOnErrorSuccess<CpLifecycleEventMonitor, OrLifecycleNode>, StUnconfigured, SUCCESS>,
+        Transition<EvTransitionOnErrorFailure<CpLifecycleEventMonitor, OrLifecycleNode>, StFinalized, ABORT>
       >
       reactions;
 

--- a/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_inactive.hpp
+++ b/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_inactive.hpp
@@ -32,9 +32,9 @@ struct StInactive : smacc2::SmaccState<StInactive, SmAtomicLifecycle>
 
   // TRANSITION TABLE
   typedef mpl::list<
-        Transition<EvTransitionCleanup<ClLifecycleNode, OrLifecycleNode>, StCleaningUp, SUCCESS>,
-        Transition<EvTransitionInactiveShutdown<ClLifecycleNode, OrLifecycleNode>, StShuttingDown, SUCCESS>,
-        Transition<EvTransitionActivate<ClLifecycleNode, OrLifecycleNode>, StActivating, SUCCESS>
+        Transition<EvTransitionCleanup<CpLifecycleEventMonitor, OrLifecycleNode>, StCleaningUp, SUCCESS>,
+        Transition<EvTransitionInactiveShutdown<CpLifecycleEventMonitor, OrLifecycleNode>, StShuttingDown, SUCCESS>,
+        Transition<EvTransitionActivate<CpLifecycleEventMonitor, OrLifecycleNode>, StActivating, SUCCESS>
       >
       reactions;
 

--- a/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_shutting_down.hpp
+++ b/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_shutting_down.hpp
@@ -32,8 +32,8 @@ struct StShuttingDown : smacc2::SmaccState<StShuttingDown, SmAtomicLifecycle>
 
   // TRANSITION TABLE
   typedef mpl::list<
-        Transition<EvTransitionOnShutdownSuccess<ClLifecycleNode, OrLifecycleNode>, StFinalized, SUCCESS>,
-        Transition<EvTransitionOnShutdownError<ClLifecycleNode, OrLifecycleNode>, StErrorProcessing, ABORT>
+        Transition<EvTransitionOnShutdownSuccess<CpLifecycleEventMonitor, OrLifecycleNode>, StFinalized, SUCCESS>,
+        Transition<EvTransitionOnShutdownError<CpLifecycleEventMonitor, OrLifecycleNode>, StErrorProcessing, ABORT>
     >reactions;
 
   // STATE FUNCTIONS

--- a/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_unconfigured.hpp
+++ b/smacc2_sm_reference_library/sm_atomic_lifecycle/include/sm_atomic_lifecycle/states/st_unconfigured.hpp
@@ -32,8 +32,8 @@ struct StUnconfigured : smacc2::SmaccState<StUnconfigured, SmAtomicLifecycle>
 
   // TRANSITION TABLE
   typedef mpl::list<
-                  Transition<EvTransitionConfigure<ClLifecycleNode, OrLifecycleNode>, StConfiguring, SUCCESS>,
-                  Transition<EvTransitionUnconfiguredShutdown<ClLifecycleNode, OrLifecycleNode>, StShuttingDown, SUCCESS>
+                  Transition<EvTransitionConfigure<CpLifecycleEventMonitor, OrLifecycleNode>, StConfiguring, SUCCESS>,
+                  Transition<EvTransitionUnconfiguredShutdown<CpLifecycleEventMonitor, OrLifecycleNode>, StShuttingDown, SUCCESS>
                   >
       reactions;
 


### PR DESCRIPTION
  Refactoring lifecycle_node to a  pure component architecture

  Client (ClLifecycleNode):
  - Thin wrapper for lifecycle service calls
  - Creates component in onStateOrthogonalAllocation() using
  createComponent<>
  - No signals, no proxy connections, no event posting

  Component (CpLifecycleEventMonitor):
  - Owns all signals and event posting logic
  - Registered with orthogonal via createComponent<>
  - Behaviors connect directly to component

  Behaviors:
  - requiresComponent(eventMonitor_) to access component
  - Connect directly to component signals
  - Pure component pattern achieved
