### PR TITLE
Enabling Event Payloads for Action Results - sm_nav2_unit_test_1 compilation warnings

### DIFF
--- a/smacc2/include/smacc2/client_core_components/cp_action_client.hpp
+++ b/smacc2/include/smacc2/client_core_components/cp_action_client.hpp
@@ -277,9 +277,10 @@ private:
   }
 
   template <typename EvType>
-  void postResultEvent(const WrappedResult & /* result */)
+  void postResultEvent(const WrappedResult & result)
   {
     auto * ev = new EvType();
+    ev->resultMessage = result;
     RCLCPP_INFO(
       getLogger(), "[%s] Posting event: %s", this->getName().c_str(),
       smacc2::demangleSymbol(typeid(ev).name()).c_str());

--- a/smacc2/include/smacc2/smacc_default_events.hpp
+++ b/smacc2/include/smacc2/smacc_default_events.hpp
@@ -47,13 +47,13 @@ struct EvActionFeedback : sc::event<EvActionFeedback<ActionFeedback, TOrthogonal
 template <typename TSource, typename TOrthogonal>
 struct EvActionResult : sc::event<EvActionResult<TSource, TOrthogonal>>
 {
-  // typename TSource::WrappedResult resultMessage;
+  typename TSource::WrappedResult resultMessage;
 };
 
 template <typename TSource, typename TOrthogonal>
 struct EvActionSucceeded : sc::event<EvActionSucceeded<TSource, TOrthogonal>>
 {
-  // typename TSource::WrappedResult resultMessage;
+  typename TSource::WrappedResult resultMessage;
 
   static std::string getEventLabel()
   {
@@ -71,7 +71,7 @@ struct EvActionSucceeded : sc::event<EvActionSucceeded<TSource, TOrthogonal>>
 template <typename TSource, typename TOrthogonal>
 struct EvActionAborted : sc::event<EvActionAborted<TSource, TOrthogonal>>
 {
-  // typename TSource::WrappedResult resultMessage;
+  typename TSource::WrappedResult resultMessage;
 
   static std::string getEventLabel()
   {
@@ -89,7 +89,7 @@ struct EvActionAborted : sc::event<EvActionAborted<TSource, TOrthogonal>>
 template <typename TSource, typename TOrthogonal>
 struct EvActionCancelled : sc::event<EvActionCancelled<TSource, TOrthogonal>>
 {
-  //typename TSource::WrappedResult resultMessage;
+  typename TSource::WrappedResult resultMessage;
 
   static std::string getEventLabel()
   {

--- a/smacc2_client_library/cl_nav2z/include/cl_nav2z/cl_nav2z.hpp
+++ b/smacc2_client_library/cl_nav2z/include/cl_nav2z/cl_nav2z.hpp
@@ -27,6 +27,12 @@ namespace cl_nav2z
 class ClNav2Z : public smacc2::ISmaccClient
 {
 public:
+  // Type aliases required for event system (TSource::WrappedResult in smacc_default_events.hpp)
+  using ActionType = nav2_msgs::action::NavigateToPose;
+  using GoalHandle = rclcpp_action::ClientGoalHandle<ActionType>;
+  using WrappedResult = typename GoalHandle::WrappedResult;
+  using Feedback = typename ActionType::Feedback;
+
   // Constructor
   ClNav2Z(std::string actionServerName = "/navigate_to_pose") : actionServerName_(actionServerName)
   {
@@ -39,7 +45,7 @@ public:
   void onComponentInitialization()
   {
     // Create core action client component
-    auto actionClient = this->createComponent<
+    this->createComponent<
       smacc2::client_core_components::CpActionClient<nav2_msgs::action::NavigateToPose>,
       TOrthogonal, ClNav2Z>(actionServerName_);
 

--- a/smacc2_client_library/cl_nav2z/include/cl_nav2z/components/nav2_action_interface/cp_nav2_action_interface.hpp
+++ b/smacc2_client_library/cl_nav2z/include/cl_nav2z/components/nav2_action_interface/cp_nav2_action_interface.hpp
@@ -124,25 +124,28 @@ public:
     postNavigationSuccessEvent = [this](const WrappedResult & result)
     {
       auto * ev = new smacc2::default_events::EvActionSucceeded<TClient, TOrthogonal>();
+      ev->resultMessage = result;
       this->postEvent(ev);
     };
 
     postNavigationAbortedEvent = [this](const WrappedResult & result)
     {
       auto * ev = new smacc2::default_events::EvActionAborted<TClient, TOrthogonal>();
+      ev->resultMessage = result;
       this->postEvent(ev);
     };
 
     postNavigationCancelledEvent = [this](const WrappedResult & result)
     {
       auto * ev = new smacc2::default_events::EvActionCancelled<TClient, TOrthogonal>();
+      ev->resultMessage = result;
       this->postEvent(ev);
     };
 
     postNavigationFeedbackEvent = [this](const Feedback & feedback)
     {
-      auto * ev = new smacc2::default_events::EvActionFeedback<TClient, TOrthogonal>();
-      //ev->feedbackMessage = feedback;
+      auto * ev = new smacc2::default_events::EvActionFeedback<Feedback, TOrthogonal>();
+      ev->feedbackMessage = feedback;
       this->postEvent(ev);
     };
 


### PR DESCRIPTION
Commit Summary: Enable Event Payloads for Action Results

  Problem

  Building sm_nav2_unit_test_1 produced 5 compiler warnings:
  - Unused variable actionClient in cl_nav2z.hpp:42
  - Unused parameter result in cp_nav2_action_interface.hpp:124,130,136
  - Unused parameter feedback in cp_nav2_action_interface.hpp:142

  Root Cause

  Action events (EvActionSucceeded, EvActionAborted, EvActionCancelled) had their
  resultMessage fields commented out. The event posting lambdas received result
  and feedback data but discarded it, creating unused parameter warnings.

  Solution

  Instead of suppressing the warnings, we enabled event payloads to align with
  the intended SMACC2 architecture where events can carry result data.

  Files Modified

  smacc2/include/smacc2/smacc_default_events.hpp
  - Uncommented resultMessage field in EvActionResult (line 50)
  - Uncommented resultMessage field in EvActionSucceeded (line 56)
  - Uncommented resultMessage field in EvActionAborted (line 74)
  - Uncommented resultMessage field in EvActionCancelled (line 92)

  smacc2/include/smacc2/client_core_components/cp_action_client.hpp
  - Modified postResultEvent() to populate ev->resultMessage = result
  - Changed parameter from const WrappedResult & /* result */ to use result

  cl_nav2z/include/cl_nav2z/components/nav2_action_interface/cp_nav2_action_interface.hpp
  - Added ev->resultMessage = result in postNavigationSuccessEvent lambda
  - Added ev->resultMessage = result in postNavigationAbortedEvent lambda
  - Added ev->resultMessage = result in postNavigationCancelledEvent lambda
  - Uncommented ev->feedbackMessage = feedback in postNavigationFeedbackEvent
  - Fixed feedback event template: EvActionFeedback<Feedback, TOrthogonal>

  cl_nav2z/include/cl_nav2z/cl_nav2z.hpp
  - Added type aliases required for event system:
    - ActionType = nav2_msgs::action::NavigateToPose
    - GoalHandle = rclcpp_action::ClientGoalHandle
    - WrappedResult = typename GoalHandle::WrappedResult
    - Feedback = typename ActionType::Feedback
  - Removed unused variable assignment from createComponent call

  Architectural Impact

  - Events now carry WrappedResult containing goal_id, result code, and result data
  - State reactors can access result data directly from events
  - Aligns CpNav2ActionInterface with core CpActionClient pattern
  - SharedPtr in WrappedResult ensures safe memory management across threads

  Packages Affected

  - smacc2 (framework core)
  - cl_nav2z (client library)
  - All state machines using cl_nav2z require rebuild

