### PR TITLE
Creation of modbus tcp client and state machine

### DIFF
--- a/docs/cl_modbus_tcp_relay_plan.md
+++ b/docs/cl_modbus_tcp_relay_plan.md
@@ -1,0 +1,820 @@
+# cl_modbus_tcp_relay Implementation Plan
+
+## Overview
+Create a SMACC2 client library for controlling an 8-channel Modbus TCP relay (Waveshare POE ETH Relay). The client uses **libmodbus** directly for Modbus TCP communication (mbpoll available separately for CLI debugging) and follows SMACC2's pure component-based architecture.
+
+## Design Decisions
+- **Library**: libmodbus C library (direct integration, not subprocess)
+- **Location**: `src/SMACC2/smacc2_client_library/cl_modbus_tcp_relay/`
+- **Behaviors**: SmaccAsyncClientBehavior for non-blocking relay operations
+
+## Target Hardware
+- **Device**: Waveshare 8-Channel POE ETH Relay
+- **Protocol**: Modbus TCP
+- **Default IP**: 192.168.1.254
+- **Default Port**: 502
+- **Slave ID**: 0x01
+- **Coil Addresses**: 0x0000-0x0007 (channels 1-8), 0x00FF (all channels)
+
+---
+
+## Architecture
+
+### Client: ClModbusTcpRelay
+Pure orchestrator that creates and configures components during initialization.
+
+**Constructor Parameters:** None - all configuration loaded from YAML config file.
+
+**YAML Configuration (in state machine's config directory):**
+```yaml
+# sm_example/config/sm_example_config.yaml
+sm_example:
+  ros__parameters:
+    modbus_relay:
+      ip_address: "192.168.1.254"
+      port: 502
+      slave_id: 1
+      heartbeat_interval_ms: 1000
+      connect_on_init: true
+```
+
+**Default Values (if not specified in config):**
+- `ip_address`: "192.168.1.254"
+- `port`: 502
+- `slave_id`: 1
+- `heartbeat_interval_ms`: 1000
+- `connect_on_init`: true
+
+### Components
+
+#### 1. CpModbusConnection
+Manages libmodbus context lifecycle, TCP connection, and heartbeat monitoring.
+
+**Responsibilities:**
+- Create/destroy modbus_t context
+- Manage TCP connection state
+- Periodic heartbeat via ISmaccUpdatable (reads coil status to verify connectivity)
+- Emit connection state change signals
+- Thread-safe connection access via mutex
+
+**Signals:**
+- `onConnectionLost_` - Emitted when heartbeat fails
+- `onConnectionRestored_` - Emitted when reconnection succeeds
+- `onConnectionError_` - Emitted on connection errors with error message
+
+**Methods:**
+- `connect()` - Establish TCP connection
+- `disconnect()` - Close connection gracefully
+- `reconnect()` - Close and re-establish connection
+- `isConnected()` - Check connection state
+- `getContext()` - Get modbus_t* for operations (thread-safe)
+
+**Pattern Reference:**
+- `CpHttpConnectionManager` for connection lifecycle
+- `CpMessageTimeout` for heartbeat/watchdog pattern
+- `ISmaccUpdatable` for periodic monitoring
+
+#### 2. CpModbusRelay
+Handles Modbus coil read/write operations for the 8-channel relay.
+
+**Responsibilities:**
+- Write single coil (channel on/off)
+- Write all coils simultaneously
+- Read single coil status
+- Read all coil statuses
+- Emit operation result signals
+
+**Signals:**
+- `onWriteSuccess_` - Emitted on successful write with channel info
+- `onWriteFailure_` - Emitted on write failure with error
+- `onReadComplete_` - Emitted with current relay states (8-bit mask)
+
+**Methods:**
+- `writeCoil(int channel, bool state)` - Write single channel (1-8)
+- `writeAllCoils(bool state)` - Write all channels
+- `writeAllCoils(uint8_t mask)` - Write all channels with bitmask
+- `readCoil(int channel)` - Read single channel state
+- `readAllCoils()` - Read all channel states
+
+**Modbus Protocol Mapping:**
+| Operation | Function Code | Address |
+|-----------|---------------|---------|
+| Single Relay ON/OFF | 0x05 | 0x0000-0x0007 |
+| All Relays ON/OFF | 0x0F | 0x0000 (8 coils) |
+| Read Single Coil | 0x01 | 0x0000-0x0007 |
+| Read All Coils | 0x01 | 0x0000 (8 coils) |
+
+---
+
+### Events
+
+```cpp
+// Connection events
+template <typename TSource, typename TOrthogonal>
+struct EvConnectionLost : sc::event<EvConnectionLost<TSource, TOrthogonal>> {};
+
+template <typename TSource, typename TOrthogonal>
+struct EvConnectionRestored : sc::event<EvConnectionRestored<TSource, TOrthogonal>> {};
+
+// Relay operation events
+template <typename TSource, typename TOrthogonal>
+struct EvRelayWriteSuccess : sc::event<EvRelayWriteSuccess<TSource, TOrthogonal>> {};
+
+template <typename TSource, typename TOrthogonal>
+struct EvRelayWriteFailure : sc::event<EvRelayWriteFailure<TSource, TOrthogonal>> {};
+```
+
+---
+
+### Client Behaviors
+
+#### CbRelayOn
+Turn on a specific relay channel.
+
+```cpp
+class CbRelayOn : public smacc2::SmaccAsyncClientBehavior
+{
+public:
+  CbRelayOn(int channel);  // channel 1-8
+
+  template <typename TOrthogonal, typename TSourceObject>
+  void onStateOrthogonalAllocation();
+
+  void onEntry() override;
+
+private:
+  int channel_;
+  CpModbusRelay* relayComponent_;
+};
+```
+
+#### CbRelayOff
+Turn off a specific relay channel.
+
+#### CbAllRelaysOn
+Turn on all 8 relay channels simultaneously.
+
+#### CbAllRelaysOff
+Turn off all 8 relay channels simultaneously.
+
+#### CbRelayStatus
+Read the status of relay channels (can be configured for single channel or all).
+
+```cpp
+class CbRelayStatus : public smacc2::SmaccAsyncClientBehavior
+{
+public:
+  CbRelayStatus();                    // Read all channels
+  CbRelayStatus(int channel);         // Read specific channel
+
+  template <typename TOrthogonal, typename TSourceObject>
+  void onStateOrthogonalAllocation();
+
+  void onEntry() override;
+
+  // Callback for read completion
+  virtual void onStatusRead(uint8_t channelStates);
+
+private:
+  std::optional<int> channel_;
+  CpModbusRelay* relayComponent_;
+};
+```
+
+---
+
+## Package Structure
+
+```
+src/SMACC2/smacc2_client_library/cl_modbus_tcp_relay/
+├── include/cl_modbus_tcp_relay/
+│   ├── cl_modbus_tcp_relay.hpp           # Main client header
+│   ├── client_behaviors/
+│   │   ├── cb_relay_on.hpp
+│   │   ├── cb_relay_off.hpp
+│   │   ├── cb_all_relays_on.hpp
+│   │   ├── cb_all_relays_off.hpp
+│   │   └── cb_relay_status.hpp
+│   └── components/
+│       ├── cp_modbus_connection.hpp
+│       └── cp_modbus_relay.hpp
+├── src/cl_modbus_tcp_relay/
+│   ├── cl_modbus_tcp_relay.cpp
+│   └── components/
+│       ├── cp_modbus_connection.cpp
+│       └── cp_modbus_relay.cpp
+├── CMakeLists.txt
+├── package.xml
+└── README.md
+```
+
+---
+
+## Implementation Details
+
+### CpModbusConnection Implementation
+
+```cpp
+class CpModbusConnection : public smacc2::ISmaccComponent, public smacc2::ISmaccUpdatable
+{
+public:
+  CpModbusConnection();  // No constructor params - config from YAML
+
+  void onInitialize() override;
+  ~CpModbusConnection();
+
+  // Connection management
+  bool connect();
+  void disconnect();
+  bool reconnect();
+  bool isConnected() const;
+
+  // Thread-safe context access
+  modbus_t* getContext();
+  std::mutex& getMutex();
+
+  // Signals
+  smacc2::SmaccSignal<void()> onConnectionLost_;
+  smacc2::SmaccSignal<void()> onConnectionRestored_;
+  smacc2::SmaccSignal<void(const std::string&)> onConnectionError_;
+
+  // Event posting (set during onStateOrthogonalAllocation)
+  template <typename TOrthogonal, typename TClient>
+  void onStateOrthogonalAllocation();
+
+protected:
+  void update() override;  // Heartbeat check
+
+private:
+  // Configuration loaded from YAML in onInitialize()
+  std::string ip_address_;
+  int port_;
+  int slave_id_;
+  int heartbeat_interval_ms_;
+  bool connect_on_init_;
+
+  modbus_t* ctx_;
+  bool connected_;
+  mutable std::mutex mutex_;
+
+  std::function<void()> postConnectionLostEvent_;
+  std::function<void()> postConnectionRestoredEvent_;
+
+  // Helper for parameter loading
+  template <typename T>
+  void declareAndLoadParam(const std::string& name, T& value, const T& default_val);
+};
+```
+
+### Parameter Loading (in onInitialize())
+
+```cpp
+void CpModbusConnection::onInitialize()
+{
+  auto node = getNode();
+
+  // Load configuration from YAML with defaults
+  ip_address_ = "192.168.1.254";
+  declareAndLoadParam("modbus_relay.ip_address", ip_address_, ip_address_);
+
+  port_ = 502;
+  declareAndLoadParam("modbus_relay.port", port_, port_);
+
+  slave_id_ = 1;
+  declareAndLoadParam("modbus_relay.slave_id", slave_id_, slave_id_);
+
+  heartbeat_interval_ms_ = 1000;
+  declareAndLoadParam("modbus_relay.heartbeat_interval_ms", heartbeat_interval_ms_, heartbeat_interval_ms_);
+
+  connect_on_init_ = true;
+  declareAndLoadParam("modbus_relay.connect_on_init", connect_on_init_, connect_on_init_);
+
+  RCLCPP_INFO(getLogger(), "[CpModbusConnection] Config: %s:%d (slave=%d, heartbeat=%dms)",
+    ip_address_.c_str(), port_, slave_id_, heartbeat_interval_ms_);
+
+  // Set update period for heartbeat
+  this->setUpdatePeriod(rclcpp::Duration::from_seconds(heartbeat_interval_ms_ / 1000.0));
+
+  // Create modbus context
+  ctx_ = modbus_new_tcp(ip_address_.c_str(), port_);
+  if (ctx_)
+  {
+    modbus_set_slave(ctx_, slave_id_);
+    modbus_set_response_timeout(ctx_, 1, 0);  // 1 second timeout
+
+    if (connect_on_init_)
+    {
+      connect();
+    }
+  }
+  else
+  {
+    RCLCPP_ERROR(getLogger(), "[CpModbusConnection] Failed to create modbus context");
+  }
+}
+
+template <typename T>
+void CpModbusConnection::declareAndLoadParam(const std::string& name, T& value, const T& default_val)
+{
+  auto node = getNode();
+  if (!node->has_parameter(name))
+  {
+    node->declare_parameter(name, default_val);
+  }
+  node->get_parameter(name, value);
+  RCLCPP_INFO(getLogger(), "[CpModbusConnection] %s: %s", name.c_str(), std::to_string(value).c_str());
+}
+```
+
+### Heartbeat Implementation (in update())
+
+```cpp
+void CpModbusConnection::update()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!ctx_) return;
+
+  // Try to read a single coil as heartbeat
+  uint8_t status;
+  int rc = modbus_read_bits(ctx_, 0x0000, 1, &status);
+
+  if (rc == -1)
+  {
+    if (connected_)
+    {
+      connected_ = false;
+      RCLCPP_WARN(getLogger(), "Modbus connection lost: %s", modbus_strerror(errno));
+      onConnectionLost_();
+      if (postConnectionLostEvent_) postConnectionLostEvent_();
+    }
+  }
+  else
+  {
+    if (!connected_)
+    {
+      connected_ = true;
+      RCLCPP_INFO(getLogger(), "Modbus connection restored");
+      onConnectionRestored_();
+      if (postConnectionRestoredEvent_) postConnectionRestoredEvent_();
+    }
+  }
+}
+```
+
+---
+
+## package.xml
+
+```xml
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>cl_modbus_tcp_relay</name>
+  <version>1.0.0</version>
+  <description>SMACC2 client for Modbus TCP relay control (8-channel)</description>
+  <maintainer email="your-email@example.com">Your Name</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
+
+  <depend>smacc2</depend>
+
+  <!-- System dependency: sudo apt install libmodbus-dev -->
+  <build_depend>libmodbus-dev</build_depend>
+  <exec_depend>libmodbus5</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>
+```
+
+---
+
+## CMakeLists.txt
+
+**Prerequisites**: Install libmodbus via `sudo apt install libmodbus-dev`
+
+```cmake
+cmake_minimum_required(VERSION 3.5)
+project(cl_modbus_tcp_relay)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(smacc2 REQUIRED)
+find_package(PkgConfig REQUIRED)
+
+# Find system-installed libmodbus
+pkg_check_modules(MODBUS REQUIRED libmodbus)
+
+include_directories(
+  include
+  ${smacc2_INCLUDE_DIRS}
+  ${MODBUS_INCLUDE_DIRS}
+)
+
+add_library(${PROJECT_NAME}
+  src/cl_modbus_tcp_relay/cl_modbus_tcp_relay.cpp
+  src/cl_modbus_tcp_relay/components/cp_modbus_connection.cpp
+  src/cl_modbus_tcp_relay/components/cp_modbus_relay.cpp
+)
+
+target_link_libraries(${PROJECT_NAME}
+  ${smacc2_LIBRARIES}
+  ${MODBUS_LIBRARIES}
+)
+
+ament_target_dependencies(${PROJECT_NAME} smacc2)
+ament_export_include_directories(include)
+ament_export_libraries(${PROJECT_NAME})
+
+install(DIRECTORY include/ DESTINATION include)
+install(TARGETS ${PROJECT_NAME} DESTINATION lib/)
+
+ament_package()
+```
+
+---
+
+## Usage Example
+
+### YAML Configuration File
+
+```yaml
+# sm_relay_test/config/sm_relay_test_config.yaml
+sm_relay_test:
+  ros__parameters:
+    modbus_relay:
+      ip_address: "192.168.1.254"
+      port: 502
+      slave_id: 1
+      heartbeat_interval_ms: 1000
+      connect_on_init: true
+```
+
+### In Orthogonal Definition
+
+```cpp
+class OrRelay : public smacc2::Orthogonal<OrRelay>
+{
+public:
+  void onInitialize() override
+  {
+    // No constructor params - config loaded from YAML
+    auto relay_client = this->createClient<cl_modbus_tcp_relay::ClModbusTcpRelay>();
+  }
+};
+```
+
+### In State Definition
+
+```cpp
+struct StActivateRelay : smacc2::SmaccState<StActivateRelay, SmRelayTest>
+{
+  using SmaccState::SmaccState;
+
+  using reactions = boost::mpl::list<
+    smacc2::Transition<EvCbSuccess<CbRelayOn, OrRelay>, StNextState>,
+    smacc2::Transition<EvCbFailure<CbRelayOn, OrRelay>, StError>,
+    smacc2::Transition<EvConnectionLost<CpModbusConnection, OrRelay>, StReconnect>
+  >;
+
+  static void staticConfigure()
+  {
+    configure_orthogonal<OrRelay, cl_modbus_tcp_relay::CbRelayOn>(1);  // Turn on channel 1
+  }
+};
+```
+
+### In Launch File
+
+```python
+# sm_relay_test/launch/sm_relay_test.launch.py
+def generate_launch_description():
+    # Load config file
+    config_file = os.path.join(
+        get_package_share_directory('sm_relay_test'),
+        'config',
+        'sm_relay_test_config.yaml'
+    )
+
+    return LaunchDescription([
+        Node(
+            package='sm_relay_test',
+            executable='sm_relay_test_node',
+            name='sm_relay_test',
+            output='screen',
+            parameters=[config_file]
+        )
+    ])
+```
+
+---
+
+## mbpoll CLI Reference
+
+For manual testing and debugging:
+
+```bash
+# Read all 8 coil states
+mbpoll -m tcp -a 1 -t 0 -r 1 -c 8 192.168.1.254
+
+# Write single coil ON (channel 1)
+mbpoll -m tcp -a 1 -t 0 -r 1 192.168.1.254 1
+
+# Write single coil OFF (channel 1)
+mbpoll -m tcp -a 1 -t 0 -r 1 192.168.1.254 0
+
+# Write all coils ON
+mbpoll -m tcp -a 1 -t 0 -r 1 -c 8 192.168.1.254 1 1 1 1 1 1 1 1
+```
+
+---
+
+## Implementation Phases (Incremental Build & Test)
+
+### Phase 1: Package Skeleton & Minimal Client (COMPILES)
+**Goal:** Create package structure that compiles with empty client.
+
+Files to create:
+- `cl_modbus_tcp_relay/package.xml`
+- `cl_modbus_tcp_relay/CMakeLists.txt`
+- `cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/cl_modbus_tcp_relay.hpp` (minimal)
+- `cl_modbus_tcp_relay/src/cl_modbus_tcp_relay/cl_modbus_tcp_relay.cpp` (minimal)
+
+**Build command:** `colcon build --packages-select cl_modbus_tcp_relay`
+
+---
+
+### Phase 2: CpModbusConnection Component (COMPILES)
+**Goal:** Connection management with libmodbus that compiles and loads config.
+
+Files to create:
+- `cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/components/cp_modbus_connection.hpp`
+- `cl_modbus_tcp_relay/src/cl_modbus_tcp_relay/components/cp_modbus_connection.cpp`
+
+Update:
+- `cl_modbus_tcp_relay.hpp` to create CpModbusConnection in onComponentInitialization()
+
+**Build command:** `colcon build --packages-select cl_modbus_tcp_relay`
+
+---
+
+### Phase 3: Test State Machine - Connection Only (RUNS)
+**Goal:** Test state machine that connects to relay and monitors heartbeat.
+
+Create new package: `sm_modbus_tcp_relay_test_1`
+
+Files to create:
+- `sm_modbus_tcp_relay_test_1/package.xml`
+- `sm_modbus_tcp_relay_test_1/CMakeLists.txt`
+- `sm_modbus_tcp_relay_test_1/config/sm_modbus_tcp_relay_test_1_config.yaml`
+- `sm_modbus_tcp_relay_test_1/launch/sm_modbus_tcp_relay_test_1.launch.py`
+- `sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/sm_modbus_tcp_relay_test_1.hpp`
+- `sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/orthogonals/or_relay.hpp`
+- `sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_connect.hpp`
+- `sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_connected.hpp`
+- `sm_modbus_tcp_relay_test_1/src/sm_modbus_tcp_relay_test_1/sm_modbus_tcp_relay_test_1.cpp`
+
+**Build command:** `colcon build --packages-select cl_modbus_tcp_relay sm_modbus_tcp_relay_test_1`
+**Run command:** `ros2 launch sm_modbus_tcp_relay_test_1 sm_modbus_tcp_relay_test_1.launch.py`
+
+---
+
+### Phase 4: CpModbusRelay Component (COMPILES)
+**Goal:** Add relay read/write operations.
+
+Files to create:
+- `cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/components/cp_modbus_relay.hpp`
+- `cl_modbus_tcp_relay/src/cl_modbus_tcp_relay/components/cp_modbus_relay.cpp`
+
+Update:
+- `cl_modbus_tcp_relay.hpp` to create CpModbusRelay in onComponentInitialization()
+
+**Build command:** `colcon build --packages-select cl_modbus_tcp_relay`
+
+---
+
+### Phase 5: CbRelayOn/CbRelayOff Behaviors (RUNS)
+**Goal:** Basic on/off behaviors with test states.
+
+Files to create:
+- `cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/client_behaviors/cb_relay_on.hpp`
+- `cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/client_behaviors/cb_relay_off.hpp`
+
+Update test state machine:
+- Add `st_relay_on.hpp` - turns on channel 1
+- Add `st_relay_off.hpp` - turns off channel 1
+- Add transitions between states
+
+**Build command:** `colcon build --packages-select cl_modbus_tcp_relay sm_modbus_tcp_relay_test_1`
+**Run command:** `ros2 launch sm_modbus_tcp_relay_test_1 sm_modbus_tcp_relay_test_1.launch.py`
+
+---
+
+### Phase 6: CbAllRelaysOn/CbAllRelaysOff (RUNS)
+**Goal:** Batch relay operations.
+
+Files to create:
+- `cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/client_behaviors/cb_all_relays_on.hpp`
+- `cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/client_behaviors/cb_all_relays_off.hpp`
+
+Update test state machine:
+- Add test states for all-on/all-off operations
+
+**Build command:** `colcon build --packages-select cl_modbus_tcp_relay sm_modbus_tcp_relay_test_1`
+
+---
+
+### Phase 7: CbRelayStatus Behavior (RUNS)
+**Goal:** Status reading behavior.
+
+Files to create:
+- `cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/client_behaviors/cb_relay_status.hpp`
+
+Update test state machine:
+- Add status monitoring state
+
+**Build command:** `colcon build --packages-select cl_modbus_tcp_relay sm_modbus_tcp_relay_test_1`
+
+---
+
+### Phase 8: Documentation & README (COMPLETE)
+**Goal:** Complete documentation.
+
+Files to create:
+- `cl_modbus_tcp_relay/README.md`
+- `sm_modbus_tcp_relay_test_1/README.md`
+
+---
+
+## Test State Machine: sm_modbus_tcp_relay_test_1
+
+### State Machine Design
+
+```
+┌─────────────────┐
+│   StConnect     │ ── EvCbSuccess ──► StRelayOn
+│  (wait connect) │ ── EvConnectionLost ──► StConnect (retry)
+└─────────────────┘
+        │
+        ▼
+┌─────────────────┐
+│   StRelayOn     │ ── EvCbSuccess ──► StWait1
+│  (channel 1 ON) │ ── EvCbFailure ──► StError
+└─────────────────┘
+        │
+        ▼
+┌─────────────────┐
+│    StWait1      │ ── EvTimer ──► StRelayOff
+│  (2 sec delay)  │
+└─────────────────┘
+        │
+        ▼
+┌─────────────────┐
+│   StRelayOff    │ ── EvCbSuccess ──► StWait2
+│  (channel 1 OFF)│ ── EvCbFailure ──► StError
+└─────────────────┘
+        │
+        ▼
+┌─────────────────┐
+│    StWait2      │ ── EvTimer ──► StAllOn
+│  (2 sec delay)  │
+└─────────────────┘
+        │
+        ▼
+┌─────────────────┐
+│    StAllOn      │ ── EvCbSuccess ──► StWait3
+│  (all channels) │
+└─────────────────┘
+        │
+        ▼
+┌─────────────────┐
+│    StWait3      │ ── EvTimer ──► StAllOff
+│  (2 sec delay)  │
+└─────────────────┘
+        │
+        ▼
+┌─────────────────┐
+│    StAllOff     │ ── EvCbSuccess ──► StComplete
+│  (all channels) │
+└─────────────────┘
+        │
+        ▼
+┌─────────────────┐
+│   StComplete    │ ── (logs success, stays) ───►
+│  (test passed)  │
+└─────────────────┘
+```
+
+### Test State Machine Config
+
+```yaml
+# sm_modbus_tcp_relay_test_1/config/sm_modbus_tcp_relay_test_1_config.yaml
+sm_modbus_tcp_relay_test_1:
+  ros__parameters:
+    # Modbus relay configuration
+    modbus_relay:
+      ip_address: "192.168.1.254"
+      port: 502
+      slave_id: 1
+      heartbeat_interval_ms: 1000
+      connect_on_init: true
+
+    # Timer configuration for wait states
+    wait_duration_ms: 2000
+```
+
+### Test State Machine Package Structure
+
+```
+smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/
+├── config/
+│   └── sm_modbus_tcp_relay_test_1_config.yaml
+├── include/sm_modbus_tcp_relay_test_1/
+│   ├── orthogonals/
+│   │   ├── or_relay.hpp
+│   │   └── or_timer.hpp
+│   ├── states/
+│   │   ├── st_connect.hpp
+│   │   ├── st_relay_on.hpp
+│   │   ├── st_relay_off.hpp
+│   │   ├── st_all_on.hpp
+│   │   ├── st_all_off.hpp
+│   │   ├── st_wait.hpp
+│   │   ├── st_complete.hpp
+│   │   └── st_error.hpp
+│   └── sm_modbus_tcp_relay_test_1.hpp
+├── launch/
+│   └── sm_modbus_tcp_relay_test_1.launch.py
+├── src/sm_modbus_tcp_relay_test_1/
+│   └── sm_modbus_tcp_relay_test_1.cpp
+├── CMakeLists.txt
+├── package.xml
+└── README.md
+```
+
+---
+
+## Files to Create
+
+### Client Library: `src/SMACC2/smacc2_client_library/cl_modbus_tcp_relay/`
+
+| File | Purpose |
+|------|---------|
+| `package.xml` | ROS2 package manifest |
+| `CMakeLists.txt` | Build configuration with libmodbus |
+| `include/cl_modbus_tcp_relay/cl_modbus_tcp_relay.hpp` | Main client |
+| `include/cl_modbus_tcp_relay/components/cp_modbus_connection.hpp` | Connection component |
+| `include/cl_modbus_tcp_relay/components/cp_modbus_relay.hpp` | Relay control component |
+| `include/cl_modbus_tcp_relay/client_behaviors/cb_relay_on.hpp` | Turn on behavior |
+| `include/cl_modbus_tcp_relay/client_behaviors/cb_relay_off.hpp` | Turn off behavior |
+| `include/cl_modbus_tcp_relay/client_behaviors/cb_all_relays_on.hpp` | All on behavior |
+| `include/cl_modbus_tcp_relay/client_behaviors/cb_all_relays_off.hpp` | All off behavior |
+| `include/cl_modbus_tcp_relay/client_behaviors/cb_relay_status.hpp` | Status read behavior |
+| `src/cl_modbus_tcp_relay/cl_modbus_tcp_relay.cpp` | Client implementation |
+| `src/cl_modbus_tcp_relay/components/cp_modbus_connection.cpp` | Connection impl |
+| `src/cl_modbus_tcp_relay/components/cp_modbus_relay.cpp` | Relay control impl |
+| `README.md` | Documentation with mbpoll examples |
+
+### Test State Machine: `src/SMACC2/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/`
+
+| File | Purpose |
+|------|---------|
+| `package.xml` | ROS2 package manifest |
+| `CMakeLists.txt` | Build configuration |
+| `config/sm_modbus_tcp_relay_test_1_config.yaml` | Modbus & timer config |
+| `launch/sm_modbus_tcp_relay_test_1.launch.py` | Launch file |
+| `include/sm_modbus_tcp_relay_test_1/sm_modbus_tcp_relay_test_1.hpp` | Main SM header |
+| `include/sm_modbus_tcp_relay_test_1/orthogonals/or_relay.hpp` | Relay orthogonal |
+| `include/sm_modbus_tcp_relay_test_1/orthogonals/or_timer.hpp` | Timer orthogonal |
+| `include/sm_modbus_tcp_relay_test_1/states/st_connect.hpp` | Initial connection state |
+| `include/sm_modbus_tcp_relay_test_1/states/st_relay_on.hpp` | Turn on channel 1 |
+| `include/sm_modbus_tcp_relay_test_1/states/st_relay_off.hpp` | Turn off channel 1 |
+| `include/sm_modbus_tcp_relay_test_1/states/st_all_on.hpp` | Turn on all channels |
+| `include/sm_modbus_tcp_relay_test_1/states/st_all_off.hpp` | Turn off all channels |
+| `include/sm_modbus_tcp_relay_test_1/states/st_wait.hpp` | Timer wait state (template) |
+| `include/sm_modbus_tcp_relay_test_1/states/st_complete.hpp` | Test complete state |
+| `include/sm_modbus_tcp_relay_test_1/states/st_error.hpp` | Error handling state |
+| `src/sm_modbus_tcp_relay_test_1/sm_modbus_tcp_relay_test_1.cpp` | Main SM source |
+| `README.md` | Test instructions |
+
+---
+
+## Reference Files (for implementation patterns)
+
+- `src/SMACC2/smacc2_client_library/cl_http/include/cl_http/cl_http.hpp`
+- `src/SMACC2/smacc2_client_library/cl_http/include/cl_http/components/cp_http_connection_manager.hpp`
+- `src/SMACC2/smacc2_client_library/cl_lifecycle_node/include/cl_lifecycle_node/client_behaviors/cb_activate.hpp`
+- `src/SMACC2/smacc2_client_library/cl_ros2_timer/include/cl_ros2_timer/components/cp_timer_listener_1.hpp`
+- `src/libmodbus/src/modbus.h`
+- `src/libmodbus/src/modbus-tcp.h`

--- a/smacc2_client_library/cl_modbus_tcp_relay/CMakeLists.txt
+++ b/smacc2_client_library/cl_modbus_tcp_relay/CMakeLists.txt
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 3.5)
+project(cl_modbus_tcp_relay)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(smacc2 REQUIRED)
+find_package(PkgConfig REQUIRED)
+
+# Find libmodbus - prefer system-installed, fallback to workspace source
+pkg_check_modules(MODBUS libmodbus)
+
+if(NOT MODBUS_FOUND)
+  # Check if libmodbus source exists in workspace
+  set(LIBMODBUS_WORKSPACE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../libmodbus/src")
+  if(EXISTS "${LIBMODBUS_WORKSPACE_PATH}/modbus.h")
+    message(STATUS "Using workspace libmodbus source at: ${LIBMODBUS_WORKSPACE_PATH}")
+    set(MODBUS_INCLUDE_DIRS ${LIBMODBUS_WORKSPACE_PATH})
+    # Note: When using workspace source, libmodbus must be built separately
+    # For full functionality, install libmodbus-dev: sudo apt install libmodbus-dev
+    set(MODBUS_LIBRARIES "modbus")
+    set(MODBUS_FOUND TRUE)
+  else()
+    message(FATAL_ERROR "libmodbus not found. Install with: sudo apt install libmodbus-dev")
+  endif()
+endif()
+
+set(dependencies
+  rclcpp
+  smacc2
+)
+
+include_directories(
+  include
+  ${MODBUS_INCLUDE_DIRS}
+)
+
+add_library(${PROJECT_NAME} SHARED
+  src/${PROJECT_NAME}/cl_modbus_tcp_relay.cpp
+  src/${PROJECT_NAME}/components/cp_modbus_connection.cpp
+  src/${PROJECT_NAME}/components/cp_modbus_relay.cpp
+)
+
+target_link_libraries(${PROJECT_NAME}
+  ${MODBUS_LIBRARIES}
+)
+
+ament_target_dependencies(${PROJECT_NAME}
+  ${dependencies}
+)
+
+ament_export_include_directories(include)
+ament_export_libraries(${PROJECT_NAME})
+ament_export_dependencies(${dependencies})
+
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(DIRECTORY include/
+  DESTINATION include/
+)
+
+ament_package()

--- a/smacc2_client_library/cl_modbus_tcp_relay/README.md
+++ b/smacc2_client_library/cl_modbus_tcp_relay/README.md
@@ -1,0 +1,240 @@
+# cl_modbus_tcp_relay
+
+SMACC2 client library for controlling Modbus TCP relay boards, specifically designed for the Waveshare 8-Channel POE ETH Relay.
+
+## Overview
+
+This client library provides a SMACC2-compatible interface for controlling relay boards via Modbus TCP protocol. It uses the libmodbus C library for communication and follows SMACC2's pure component-based architecture.
+
+## Target Hardware
+
+- **Device**: Waveshare 8-Channel POE ETH Relay (or compatible)
+- **Protocol**: Modbus TCP
+- **Default IP**: 192.168.1.254
+- **Default Port**: 502
+- **Slave ID**: 0x01
+- **Coil Addresses**: 0x0000-0x0007 (channels 1-8)
+
+## Dependencies
+
+### System Dependencies
+
+```bash
+sudo apt install libmodbus-dev
+```
+
+### ROS2 Dependencies
+
+- smacc2
+
+## Architecture
+
+### Client: ClModbusTcpRelay
+
+Pure orchestrator that creates and configures components during initialization. Configuration is loaded from YAML parameters.
+
+### Components
+
+#### CpModbusConnection
+
+Manages libmodbus context lifecycle, TCP connection, and heartbeat monitoring.
+
+**Responsibilities:**
+- Create/destroy modbus_t context
+- Manage TCP connection state
+- Periodic heartbeat via ISmaccUpdatable
+- Emit connection state change signals
+- Thread-safe connection access via mutex
+
+**Signals:**
+- `onConnectionLost_` - Emitted when heartbeat fails
+- `onConnectionRestored_` - Emitted when reconnection succeeds
+- `onConnectionError_` - Emitted on connection errors
+
+#### CpModbusRelay
+
+Handles Modbus coil read/write operations for the 8-channel relay.
+
+**Methods:**
+- `writeCoil(int channel, bool state)` - Write single channel (1-8)
+- `writeAllCoils(bool state)` - Write all channels ON or OFF
+- `writeAllCoils(uint8_t mask)` - Write all channels with bitmask
+- `readCoil(int channel)` - Read single channel state
+- `readAllCoils()` - Read all channel states
+
+### Client Behaviors
+
+| Behavior | Description |
+|----------|-------------|
+| `CbRelayOn` | Turn on a specific relay channel (1-8) |
+| `CbRelayOff` | Turn off a specific relay channel (1-8) |
+| `CbAllRelaysOn` | Turn on all 8 relay channels |
+| `CbAllRelaysOff` | Turn off all 8 relay channels |
+| `CbRelayStatus` | Read the status of relay channels |
+
+### Events
+
+```cpp
+// Connection events (source: CpModbusConnection)
+EvConnectionLost<CpModbusConnection, OrRelay>
+EvConnectionRestored<CpModbusConnection, OrRelay>
+
+// Relay operation events (source: CpModbusRelay)
+EvRelayWriteSuccess<CpModbusRelay, OrRelay>
+EvRelayWriteFailure<CpModbusRelay, OrRelay>
+```
+
+## Configuration
+
+Configuration is loaded from ROS2 parameters (typically via YAML config file):
+
+```yaml
+your_state_machine:
+  ros__parameters:
+    modbus_relay:
+      ip_address: "192.168.1.254"    # Relay board IP address
+      port: 502                       # Modbus TCP port
+      slave_id: 1                     # Modbus slave ID
+      heartbeat_interval_ms: 1000     # Heartbeat check interval
+      connect_on_init: true           # Auto-connect on initialization
+```
+
+### Default Values
+
+| Parameter | Default |
+|-----------|---------|
+| `ip_address` | "192.168.1.254" |
+| `port` | 502 |
+| `slave_id` | 1 |
+| `heartbeat_interval_ms` | 1000 |
+| `connect_on_init` | true |
+
+## Usage
+
+### Orthogonal Definition
+
+```cpp
+#include <cl_modbus_tcp_relay/cl_modbus_tcp_relay.hpp>
+
+class OrRelay : public smacc2::Orthogonal<OrRelay>
+{
+public:
+  void onInitialize() override
+  {
+    // Configuration loaded from YAML parameters
+    auto relay_client = this->createClient<cl_modbus_tcp_relay::ClModbusTcpRelay>();
+  }
+};
+```
+
+### State Definition
+
+```cpp
+#include <cl_modbus_tcp_relay/client_behaviors/cb_relay_on.hpp>
+#include <cl_modbus_tcp_relay/client_behaviors/cb_relay_off.hpp>
+
+struct StActivateRelay : smacc2::SmaccState<StActivateRelay, SmExample>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+    Transition<EvCbSuccess<CbRelayOn, OrRelay>, StNextState>,
+    Transition<EvCbFailure<CbRelayOn, OrRelay>, StError>,
+    Transition<EvConnectionLost<CpModbusConnection, OrRelay>, StReconnect>
+  > reactions;
+
+  static void staticConfigure()
+  {
+    // Turn on channel 1
+    configure_orthogonal<OrRelay, cl_modbus_tcp_relay::CbRelayOn>(1);
+  }
+};
+```
+
+### Launch File
+
+```python
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+import os
+
+def generate_launch_description():
+    config_file = os.path.join(
+        get_package_share_directory('your_state_machine'),
+        'config',
+        'your_config.yaml'
+    )
+
+    return LaunchDescription([
+        Node(
+            package='your_state_machine',
+            executable='your_state_machine_node',
+            name='your_state_machine',
+            output='screen',
+            parameters=[config_file]
+        )
+    ])
+```
+
+## Manual Testing with mbpoll
+
+For debugging and manual testing, you can use the `mbpoll` command-line tool:
+
+```bash
+# Install mbpoll
+sudo apt install mbpoll
+
+# Read all 8 coil states
+mbpoll -m tcp -a 1 -t 0 -r 1 -c 8 192.168.1.254
+
+# Write single coil ON (channel 1)
+mbpoll -m tcp -a 1 -t 0 -r 1 192.168.1.254 1
+
+# Write single coil OFF (channel 1)
+mbpoll -m tcp -a 1 -t 0 -r 1 192.168.1.254 0
+
+# Write all coils ON
+mbpoll -m tcp -a 1 -t 0 -r 1 -c 8 192.168.1.254 1 1 1 1 1 1 1 1
+
+# Write all coils OFF
+mbpoll -m tcp -a 1 -t 0 -r 1 -c 8 192.168.1.254 0 0 0 0 0 0 0 0
+```
+
+### mbpoll Options Reference
+
+| Option | Description |
+|--------|-------------|
+| `-m tcp` | Use Modbus TCP protocol |
+| `-a 1` | Slave address (1) |
+| `-t 0` | Data type: coil (0) |
+| `-r 1` | Starting reference (1 = address 0x0000) |
+| `-c 8` | Number of coils to read/write |
+
+## Modbus Protocol Reference
+
+| Operation | Function Code | Address Range |
+|-----------|---------------|---------------|
+| Read Coils | 0x01 | 0x0000-0x0007 |
+| Write Single Coil | 0x05 | 0x0000-0x0007 |
+| Write Multiple Coils | 0x0F | 0x0000 (8 coils) |
+
+### Coil Values
+
+- ON: 0xFF00 (function 0x05) or 1 (function 0x0F)
+- OFF: 0x0000
+
+## Building
+
+```bash
+# From workspace root
+colcon build --packages-select cl_modbus_tcp_relay
+```
+
+## Test State Machine
+
+See `sm_modbus_tcp_relay_test_1` for a complete test state machine that exercises all behaviors.
+
+## License
+
+Apache-2.0

--- a/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/cl_modbus_tcp_relay.hpp
+++ b/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/cl_modbus_tcp_relay.hpp
@@ -1,0 +1,106 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*****************************************************************************************************************
+ *
+ *   Authors: Pablo Inigo Blasco, Brett Aldrich
+ *
+ ******************************************************************************************************************/
+#pragma once
+
+#include <cl_modbus_tcp_relay/components/cp_modbus_connection.hpp>
+#include <cl_modbus_tcp_relay/components/cp_modbus_relay.hpp>
+#include <smacc2/smacc.hpp>
+
+namespace cl_modbus_tcp_relay
+{
+
+// Connection events
+template <typename TSource, typename TOrthogonal>
+struct EvConnectionLost : sc::event<EvConnectionLost<TSource, TOrthogonal>>
+{
+};
+
+template <typename TSource, typename TOrthogonal>
+struct EvConnectionRestored : sc::event<EvConnectionRestored<TSource, TOrthogonal>>
+{
+};
+
+// Relay operation events
+template <typename TSource, typename TOrthogonal>
+struct EvRelayWriteSuccess : sc::event<EvRelayWriteSuccess<TSource, TOrthogonal>>
+{
+};
+
+template <typename TSource, typename TOrthogonal>
+struct EvRelayWriteFailure : sc::event<EvRelayWriteFailure<TSource, TOrthogonal>>
+{
+};
+
+/**
+ * @brief SMACC2 Client for controlling Modbus TCP relays
+ *
+ * This client manages connection and control of Modbus TCP relay devices,
+ * specifically designed for 8-channel relays like the Waveshare POE ETH Relay.
+ *
+ * Configuration is loaded from YAML parameters:
+ *   modbus_relay.ip_address: IP address of the relay (default: "192.168.1.254")
+ *   modbus_relay.port: Modbus TCP port (default: 502)
+ *   modbus_relay.slave_id: Modbus slave ID (default: 1)
+ *   modbus_relay.heartbeat_interval_ms: Heartbeat check interval (default: 1000)
+ *   modbus_relay.connect_on_init: Connect automatically on init (default: true)
+ */
+class ClModbusTcpRelay : public smacc2::ISmaccClient
+{
+public:
+  ClModbusTcpRelay();
+
+  virtual ~ClModbusTcpRelay();
+
+  void onInitialize() override;
+
+  template <typename TOrthogonal, typename TSourceObject>
+  void onStateOrthogonalAllocation()
+  {
+    // Create connection component if not already created
+    if (!connectionComponent_)
+    {
+      connectionComponent_ =
+        this->template createComponent<CpModbusConnection, TOrthogonal, ClModbusTcpRelay>();
+    }
+
+    // Create relay component if not already created
+    if (!relayComponent_)
+    {
+      relayComponent_ =
+        this->template createComponent<CpModbusRelay, TOrthogonal, ClModbusTcpRelay>();
+    }
+
+    // Configure components for this orthogonal
+    connectionComponent_->template onStateOrthogonalAllocation<TOrthogonal, ClModbusTcpRelay>();
+    relayComponent_->template onStateOrthogonalAllocation<TOrthogonal, ClModbusTcpRelay>();
+  }
+
+  // Accessor for connection component
+  CpModbusConnection * getConnectionComponent() { return connectionComponent_; }
+
+  // Accessor for relay component
+  CpModbusRelay * getRelayComponent() { return relayComponent_; }
+
+private:
+  CpModbusConnection * connectionComponent_ = nullptr;
+  CpModbusRelay * relayComponent_ = nullptr;
+};
+
+}  // namespace cl_modbus_tcp_relay

--- a/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/client_behaviors/cb_all_relays_off.hpp
+++ b/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/client_behaviors/cb_all_relays_off.hpp
@@ -1,0 +1,80 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*****************************************************************************************************************
+ *
+ *   Authors: Pablo Inigo Blasco, Brett Aldrich
+ *
+ ******************************************************************************************************************/
+
+#pragma once
+
+#include <cl_modbus_tcp_relay/cl_modbus_tcp_relay.hpp>
+#include <smacc2/smacc_asynchronous_client_behavior.hpp>
+
+namespace cl_modbus_tcp_relay
+{
+
+/**
+ * @brief Client behavior to turn OFF all relay channels simultaneously
+ *
+ * Posts EvCbSuccess on successful write, EvCbFailure on error.
+ */
+class CbAllRelaysOff : public smacc2::SmaccAsyncClientBehavior
+{
+public:
+  CbAllRelaysOff() {}
+
+  virtual ~CbAllRelaysOff() {}
+
+  template <typename TOrthogonal, typename TSourceObject>
+  void onStateOrthogonalAllocation()
+  {
+    smacc2::SmaccAsyncClientBehavior::onStateOrthogonalAllocation<TOrthogonal, TSourceObject>();
+
+    this->requiresClient(client_);
+    this->requiresComponent(relayComponent_);
+  }
+
+  virtual void onEntry() override
+  {
+    RCLCPP_INFO(getLogger(), "[CbAllRelaysOff] Turning OFF all channels");
+
+    if (!relayComponent_)
+    {
+      RCLCPP_ERROR(getLogger(), "[CbAllRelaysOff] Relay component not available");
+      this->postFailureEvent();
+      return;
+    }
+
+    bool success = relayComponent_->writeAllCoils(false);
+
+    if (success)
+    {
+      RCLCPP_INFO(getLogger(), "[CbAllRelaysOff] All channels turned OFF successfully");
+      this->postSuccessEvent();
+    }
+    else
+    {
+      RCLCPP_ERROR(getLogger(), "[CbAllRelaysOff] Failed to turn OFF all channels");
+      this->postFailureEvent();
+    }
+  }
+
+private:
+  ClModbusTcpRelay * client_;
+  CpModbusRelay * relayComponent_;
+};
+
+}  // namespace cl_modbus_tcp_relay

--- a/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/client_behaviors/cb_all_relays_on.hpp
+++ b/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/client_behaviors/cb_all_relays_on.hpp
@@ -1,0 +1,80 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*****************************************************************************************************************
+ *
+ *   Authors: Pablo Inigo Blasco, Brett Aldrich
+ *
+ ******************************************************************************************************************/
+
+#pragma once
+
+#include <cl_modbus_tcp_relay/cl_modbus_tcp_relay.hpp>
+#include <smacc2/smacc_asynchronous_client_behavior.hpp>
+
+namespace cl_modbus_tcp_relay
+{
+
+/**
+ * @brief Client behavior to turn ON all relay channels simultaneously
+ *
+ * Posts EvCbSuccess on successful write, EvCbFailure on error.
+ */
+class CbAllRelaysOn : public smacc2::SmaccAsyncClientBehavior
+{
+public:
+  CbAllRelaysOn() {}
+
+  virtual ~CbAllRelaysOn() {}
+
+  template <typename TOrthogonal, typename TSourceObject>
+  void onStateOrthogonalAllocation()
+  {
+    smacc2::SmaccAsyncClientBehavior::onStateOrthogonalAllocation<TOrthogonal, TSourceObject>();
+
+    this->requiresClient(client_);
+    this->requiresComponent(relayComponent_);
+  }
+
+  virtual void onEntry() override
+  {
+    RCLCPP_INFO(getLogger(), "[CbAllRelaysOn] Turning ON all channels");
+
+    if (!relayComponent_)
+    {
+      RCLCPP_ERROR(getLogger(), "[CbAllRelaysOn] Relay component not available");
+      this->postFailureEvent();
+      return;
+    }
+
+    bool success = relayComponent_->writeAllCoils(true);
+
+    if (success)
+    {
+      RCLCPP_INFO(getLogger(), "[CbAllRelaysOn] All channels turned ON successfully");
+      this->postSuccessEvent();
+    }
+    else
+    {
+      RCLCPP_ERROR(getLogger(), "[CbAllRelaysOn] Failed to turn ON all channels");
+      this->postFailureEvent();
+    }
+  }
+
+private:
+  ClModbusTcpRelay * client_;
+  CpModbusRelay * relayComponent_;
+};
+
+}  // namespace cl_modbus_tcp_relay

--- a/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/client_behaviors/cb_relay_off.hpp
+++ b/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/client_behaviors/cb_relay_off.hpp
@@ -1,0 +1,85 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*****************************************************************************************************************
+ *
+ *   Authors: Pablo Inigo Blasco, Brett Aldrich
+ *
+ ******************************************************************************************************************/
+
+#pragma once
+
+#include <cl_modbus_tcp_relay/cl_modbus_tcp_relay.hpp>
+#include <smacc2/smacc_asynchronous_client_behavior.hpp>
+
+namespace cl_modbus_tcp_relay
+{
+
+/**
+ * @brief Client behavior to turn OFF a specific relay channel
+ *
+ * Posts EvCbSuccess on successful write, EvCbFailure on error.
+ */
+class CbRelayOff : public smacc2::SmaccAsyncClientBehavior
+{
+public:
+  /**
+   * @brief Construct behavior to turn off specified channel
+   * @param channel Relay channel number (1-8)
+   */
+  explicit CbRelayOff(int channel) : channel_(channel) {}
+
+  virtual ~CbRelayOff() {}
+
+  template <typename TOrthogonal, typename TSourceObject>
+  void onStateOrthogonalAllocation()
+  {
+    smacc2::SmaccAsyncClientBehavior::onStateOrthogonalAllocation<TOrthogonal, TSourceObject>();
+
+    this->requiresClient(client_);
+    this->requiresComponent(relayComponent_);
+  }
+
+  virtual void onEntry() override
+  {
+    RCLCPP_INFO(getLogger(), "[CbRelayOff] Turning OFF channel %d", channel_);
+
+    if (!relayComponent_)
+    {
+      RCLCPP_ERROR(getLogger(), "[CbRelayOff] Relay component not available");
+      this->postFailureEvent();
+      return;
+    }
+
+    bool success = relayComponent_->writeCoil(channel_, false);
+
+    if (success)
+    {
+      RCLCPP_INFO(getLogger(), "[CbRelayOff] Channel %d turned OFF successfully", channel_);
+      this->postSuccessEvent();
+    }
+    else
+    {
+      RCLCPP_ERROR(getLogger(), "[CbRelayOff] Failed to turn OFF channel %d", channel_);
+      this->postFailureEvent();
+    }
+  }
+
+private:
+  int channel_;
+  ClModbusTcpRelay * client_;
+  CpModbusRelay * relayComponent_;
+};
+
+}  // namespace cl_modbus_tcp_relay

--- a/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/client_behaviors/cb_relay_on.hpp
+++ b/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/client_behaviors/cb_relay_on.hpp
@@ -1,0 +1,85 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*****************************************************************************************************************
+ *
+ *   Authors: Pablo Inigo Blasco, Brett Aldrich
+ *
+ ******************************************************************************************************************/
+
+#pragma once
+
+#include <cl_modbus_tcp_relay/cl_modbus_tcp_relay.hpp>
+#include <smacc2/smacc_asynchronous_client_behavior.hpp>
+
+namespace cl_modbus_tcp_relay
+{
+
+/**
+ * @brief Client behavior to turn ON a specific relay channel
+ *
+ * Posts EvCbSuccess on successful write, EvCbFailure on error.
+ */
+class CbRelayOn : public smacc2::SmaccAsyncClientBehavior
+{
+public:
+  /**
+   * @brief Construct behavior to turn on specified channel
+   * @param channel Relay channel number (1-8)
+   */
+  explicit CbRelayOn(int channel) : channel_(channel) {}
+
+  virtual ~CbRelayOn() {}
+
+  template <typename TOrthogonal, typename TSourceObject>
+  void onStateOrthogonalAllocation()
+  {
+    smacc2::SmaccAsyncClientBehavior::onStateOrthogonalAllocation<TOrthogonal, TSourceObject>();
+
+    this->requiresClient(client_);
+    this->requiresComponent(relayComponent_);
+  }
+
+  virtual void onEntry() override
+  {
+    RCLCPP_INFO(getLogger(), "[CbRelayOn] Turning ON channel %d", channel_);
+
+    if (!relayComponent_)
+    {
+      RCLCPP_ERROR(getLogger(), "[CbRelayOn] Relay component not available");
+      this->postFailureEvent();
+      return;
+    }
+
+    bool success = relayComponent_->writeCoil(channel_, true);
+
+    if (success)
+    {
+      RCLCPP_INFO(getLogger(), "[CbRelayOn] Channel %d turned ON successfully", channel_);
+      this->postSuccessEvent();
+    }
+    else
+    {
+      RCLCPP_ERROR(getLogger(), "[CbRelayOn] Failed to turn ON channel %d", channel_);
+      this->postFailureEvent();
+    }
+  }
+
+private:
+  int channel_;
+  ClModbusTcpRelay * client_;
+  CpModbusRelay * relayComponent_;
+};
+
+}  // namespace cl_modbus_tcp_relay

--- a/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/client_behaviors/cb_relay_status.hpp
+++ b/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/client_behaviors/cb_relay_status.hpp
@@ -84,8 +84,7 @@ public:
    */
   virtual void onStatusRead(uint8_t channelStates)
   {
-    RCLCPP_INFO(
-      getLogger(), "[CbRelayStatus] Status read callback: 0x%02X", channelStates);
+    RCLCPP_INFO(getLogger(), "[CbRelayStatus] Status read callback: 0x%02X", channelStates);
   }
 
 private:
@@ -111,9 +110,7 @@ private:
     if (success)
     {
       channelStates_ = state ? (1 << (channel - 1)) : 0;
-      RCLCPP_INFO(
-        getLogger(), "[CbRelayStatus] Channel %d is %s",
-        channel, state ? "ON" : "OFF");
+      RCLCPP_INFO(getLogger(), "[CbRelayStatus] Channel %d is %s", channel, state ? "ON" : "OFF");
       onStatusRead(channelStates_);
       this->postSuccessEvent();
     }
@@ -145,9 +142,7 @@ private:
       for (int i = 0; i < 8; i++)
       {
         bool state = (channelStates_ & (1 << i)) != 0;
-        RCLCPP_INFO(
-          getLogger(), "[CbRelayStatus]   Channel %d: %s",
-          i + 1, state ? "ON" : "OFF");
+        RCLCPP_INFO(getLogger(), "[CbRelayStatus]   Channel %d: %s", i + 1, state ? "ON" : "OFF");
       }
 
       onStatusRead(channelStates_);

--- a/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/client_behaviors/cb_relay_status.hpp
+++ b/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/client_behaviors/cb_relay_status.hpp
@@ -1,0 +1,164 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*****************************************************************************************************************
+ *
+ *   Authors: Pablo Inigo Blasco, Brett Aldrich
+ *
+ ******************************************************************************************************************/
+
+#pragma once
+
+#include <cl_modbus_tcp_relay/cl_modbus_tcp_relay.hpp>
+#include <smacc2/smacc_asynchronous_client_behavior.hpp>
+
+#include <optional>
+
+namespace cl_modbus_tcp_relay
+{
+
+/**
+ * @brief Client behavior to read relay channel status
+ *
+ * Can read single channel or all channels.
+ * Posts EvCbSuccess on successful read, EvCbFailure on error.
+ */
+class CbRelayStatus : public smacc2::SmaccAsyncClientBehavior
+{
+public:
+  /**
+   * @brief Construct behavior to read all channel statuses
+   */
+  CbRelayStatus() : channel_(std::nullopt) {}
+
+  /**
+   * @brief Construct behavior to read a specific channel status
+   * @param channel Relay channel number (1-8)
+   */
+  explicit CbRelayStatus(int channel) : channel_(channel) {}
+
+  virtual ~CbRelayStatus() {}
+
+  template <typename TOrthogonal, typename TSourceObject>
+  void onStateOrthogonalAllocation()
+  {
+    smacc2::SmaccAsyncClientBehavior::onStateOrthogonalAllocation<TOrthogonal, TSourceObject>();
+
+    this->requiresClient(client_);
+    this->requiresComponent(relayComponent_);
+  }
+
+  virtual void onEntry() override
+  {
+    if (channel_.has_value())
+    {
+      readSingleChannel(channel_.value());
+    }
+    else
+    {
+      readAllChannels();
+    }
+  }
+
+  /**
+   * @brief Get the last read channel states (bitmask)
+   * @return Bitmask of channel states (bit 0 = channel 1, etc.)
+   */
+  uint8_t getChannelStates() const { return channelStates_; }
+
+  /**
+   * @brief Virtual callback for status read completion
+   * Override in derived classes for custom handling
+   * @param channelStates Bitmask of channel states
+   */
+  virtual void onStatusRead(uint8_t channelStates)
+  {
+    RCLCPP_INFO(
+      getLogger(), "[CbRelayStatus] Status read callback: 0x%02X", channelStates);
+  }
+
+private:
+  std::optional<int> channel_;
+  ClModbusTcpRelay * client_;
+  CpModbusRelay * relayComponent_;
+  uint8_t channelStates_ = 0;
+
+  void readSingleChannel(int channel)
+  {
+    RCLCPP_INFO(getLogger(), "[CbRelayStatus] Reading channel %d status", channel);
+
+    if (!relayComponent_)
+    {
+      RCLCPP_ERROR(getLogger(), "[CbRelayStatus] Relay component not available");
+      this->postFailureEvent();
+      return;
+    }
+
+    bool state;
+    bool success = relayComponent_->readCoil(channel, state);
+
+    if (success)
+    {
+      channelStates_ = state ? (1 << (channel - 1)) : 0;
+      RCLCPP_INFO(
+        getLogger(), "[CbRelayStatus] Channel %d is %s",
+        channel, state ? "ON" : "OFF");
+      onStatusRead(channelStates_);
+      this->postSuccessEvent();
+    }
+    else
+    {
+      RCLCPP_ERROR(getLogger(), "[CbRelayStatus] Failed to read channel %d", channel);
+      this->postFailureEvent();
+    }
+  }
+
+  void readAllChannels()
+  {
+    RCLCPP_INFO(getLogger(), "[CbRelayStatus] Reading all channel statuses");
+
+    if (!relayComponent_)
+    {
+      RCLCPP_ERROR(getLogger(), "[CbRelayStatus] Relay component not available");
+      this->postFailureEvent();
+      return;
+    }
+
+    bool success = relayComponent_->readAllCoils(channelStates_);
+
+    if (success)
+    {
+      RCLCPP_INFO(getLogger(), "[CbRelayStatus] All channel statuses: 0x%02X", channelStates_);
+
+      // Log individual channel states
+      for (int i = 0; i < 8; i++)
+      {
+        bool state = (channelStates_ & (1 << i)) != 0;
+        RCLCPP_INFO(
+          getLogger(), "[CbRelayStatus]   Channel %d: %s",
+          i + 1, state ? "ON" : "OFF");
+      }
+
+      onStatusRead(channelStates_);
+      this->postSuccessEvent();
+    }
+    else
+    {
+      RCLCPP_ERROR(getLogger(), "[CbRelayStatus] Failed to read channel statuses");
+      this->postFailureEvent();
+    }
+  }
+};
+
+}  // namespace cl_modbus_tcp_relay

--- a/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/components/cp_modbus_connection.hpp
+++ b/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/components/cp_modbus_connection.hpp
@@ -1,0 +1,142 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*****************************************************************************************************************
+ *
+ *   Authors: Pablo Inigo Blasco, Brett Aldrich
+ *
+ ******************************************************************************************************************/
+#pragma once
+
+#include <modbus/modbus.h>
+
+#include <functional>
+#include <mutex>
+#include <smacc2/smacc.hpp>
+#include <string>
+
+namespace cl_modbus_tcp_relay
+{
+
+// Forward declarations for events
+template <typename TSource, typename TOrthogonal>
+struct EvConnectionLost;
+
+template <typename TSource, typename TOrthogonal>
+struct EvConnectionRestored;
+
+/**
+ * @brief Component that manages Modbus TCP connection lifecycle and heartbeat monitoring
+ *
+ * Responsibilities:
+ * - Create/destroy modbus_t context
+ * - Manage TCP connection state
+ * - Periodic heartbeat via ISmaccUpdatable (reads coil status to verify connectivity)
+ * - Emit connection state change signals
+ * - Thread-safe connection access via mutex
+ *
+ * Configuration is loaded from YAML parameters:
+ *   modbus_relay.ip_address: IP address of the relay (default: "192.168.1.254")
+ *   modbus_relay.port: Modbus TCP port (default: 502)
+ *   modbus_relay.slave_id: Modbus slave ID (default: 1)
+ *   modbus_relay.heartbeat_interval_ms: Heartbeat check interval (default: 1000)
+ *   modbus_relay.connect_on_init: Connect automatically on init (default: true)
+ */
+class CpModbusConnection : public smacc2::ISmaccComponent, public smacc2::ISmaccUpdatable
+{
+public:
+  CpModbusConnection();
+  virtual ~CpModbusConnection();
+
+  void onInitialize() override;
+
+  /**
+   * @brief Configure component for event posting during orthogonal allocation
+   */
+  template <typename TOrthogonal, typename TClient>
+  void onStateOrthogonalAllocation()
+  {
+    postConnectionLostEvent_ = [this]()
+    { this->template postEvent<EvConnectionLost<CpModbusConnection, TOrthogonal>>(); };
+
+    postConnectionRestoredEvent_ = [this]()
+    { this->template postEvent<EvConnectionRestored<CpModbusConnection, TOrthogonal>>(); };
+  }
+
+  // Connection management
+  bool connect();
+  void disconnect();
+  bool reconnect();
+  bool isConnected() const;
+
+  // Thread-safe context access
+  modbus_t * getContext();
+  std::mutex & getMutex();
+
+  // Configuration accessors
+  std::string getIpAddress() const { return ip_address_; }
+  int getPort() const { return port_; }
+  int getSlaveId() const { return slave_id_; }
+
+  // Signals for connection state changes
+  smacc2::SmaccSignal<void()> onConnectionLost_;
+  smacc2::SmaccSignal<void()> onConnectionRestored_;
+  smacc2::SmaccSignal<void(const std::string &)> onConnectionError_;
+
+  // Signal connection helpers
+  template <typename T>
+  smacc2::SmaccSignalConnection onConnectionLost(void (T::*callback)(), T * object)
+  {
+    return this->getStateMachine()->createSignalConnection(onConnectionLost_, callback, object);
+  }
+
+  template <typename T>
+  smacc2::SmaccSignalConnection onConnectionRestored(void (T::*callback)(), T * object)
+  {
+    return this->getStateMachine()->createSignalConnection(onConnectionRestored_, callback, object);
+  }
+
+  template <typename T>
+  smacc2::SmaccSignalConnection onConnectionError(
+    void (T::*callback)(const std::string &), T * object)
+  {
+    return this->getStateMachine()->createSignalConnection(onConnectionError_, callback, object);
+  }
+
+protected:
+  void update() override;  // Heartbeat check
+
+private:
+  // Configuration loaded from YAML in onInitialize()
+  std::string ip_address_;
+  int port_;
+  int slave_id_;
+  int heartbeat_interval_ms_;
+  bool connect_on_init_;
+
+  // Modbus context
+  modbus_t * ctx_;
+  bool connected_;
+  mutable std::mutex mutex_;
+
+  // Event posting functions
+  std::function<void()> postConnectionLostEvent_;
+  std::function<void()> postConnectionRestoredEvent_;
+
+  // Helper for parameter loading
+  template <typename T>
+  void declareAndLoadParam(const std::string & name, T & value, const T & default_val);
+};
+
+}  // namespace cl_modbus_tcp_relay

--- a/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/components/cp_modbus_relay.hpp
+++ b/smacc2_client_library/cl_modbus_tcp_relay/include/cl_modbus_tcp_relay/components/cp_modbus_relay.hpp
@@ -1,0 +1,122 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*****************************************************************************************************************
+ *
+ *   Authors: Pablo Inigo Blasco, Brett Aldrich
+ *
+ ******************************************************************************************************************/
+#pragma once
+
+#include <cl_modbus_tcp_relay/components/cp_modbus_connection.hpp>
+#include <smacc2/smacc.hpp>
+
+#include <cstdint>
+#include <functional>
+
+namespace cl_modbus_tcp_relay
+{
+
+// Forward declarations for events
+template <typename TSource, typename TOrthogonal>
+struct EvRelayWriteSuccess;
+
+template <typename TSource, typename TOrthogonal>
+struct EvRelayWriteFailure;
+
+/**
+ * @brief Component that handles Modbus coil read/write operations for 8-channel relay
+ *
+ * Responsibilities:
+ * - Write single coil (channel on/off)
+ * - Write all coils simultaneously
+ * - Read single coil status
+ * - Read all coil statuses
+ * - Emit operation result signals
+ *
+ * Channel numbering: 1-8 (user-friendly)
+ * Coil addresses: 0x0000-0x0007 (0-indexed internally)
+ */
+class CpModbusRelay : public smacc2::ISmaccComponent
+{
+public:
+  static constexpr int NUM_CHANNELS = 8;
+  static constexpr int COIL_BASE_ADDRESS = 0x0000;
+
+  CpModbusRelay();
+  virtual ~CpModbusRelay();
+
+  void onInitialize() override;
+
+  /**
+   * @brief Configure component for event posting during orthogonal allocation
+   */
+  template <typename TOrthogonal, typename TClient>
+  void onStateOrthogonalAllocation()
+  {
+    postWriteSuccessEvent_ = [this]()
+    { this->template postEvent<EvRelayWriteSuccess<CpModbusRelay, TOrthogonal>>(); };
+
+    postWriteFailureEvent_ = [this]()
+    { this->template postEvent<EvRelayWriteFailure<CpModbusRelay, TOrthogonal>>(); };
+  }
+
+  // Single channel operations (channel 1-8)
+  bool writeCoil(int channel, bool state);
+  bool readCoil(int channel, bool & state);
+
+  // All channels operations
+  bool writeAllCoils(bool state);
+  bool writeAllCoils(uint8_t mask);
+  bool readAllCoils(uint8_t & states);
+
+  // Signals for operation results
+  smacc2::SmaccSignal<void(int channel, bool state)> onWriteSuccess_;
+  smacc2::SmaccSignal<void(int channel, const std::string & error)> onWriteFailure_;
+  smacc2::SmaccSignal<void(uint8_t states)> onReadComplete_;
+
+  // Signal connection helpers
+  template <typename T>
+  smacc2::SmaccSignalConnection onWriteSuccess(void (T::*callback)(int, bool), T * object)
+  {
+    return this->getStateMachine()->createSignalConnection(onWriteSuccess_, callback, object);
+  }
+
+  template <typename T>
+  smacc2::SmaccSignalConnection onWriteFailure(
+    void (T::*callback)(int, const std::string &), T * object)
+  {
+    return this->getStateMachine()->createSignalConnection(onWriteFailure_, callback, object);
+  }
+
+  template <typename T>
+  smacc2::SmaccSignalConnection onReadComplete(void (T::*callback)(uint8_t), T * object)
+  {
+    return this->getStateMachine()->createSignalConnection(onReadComplete_, callback, object);
+  }
+
+private:
+  CpModbusConnection * connectionComponent_;
+
+  std::function<void()> postWriteSuccessEvent_;
+  std::function<void()> postWriteFailureEvent_;
+
+  // Helper to convert channel (1-8) to coil address (0-7)
+  int channelToAddress(int channel) const { return COIL_BASE_ADDRESS + (channel - 1); }
+
+  // Validate channel number
+  bool isValidChannel(int channel) const { return channel >= 1 && channel <= NUM_CHANNELS; }
+};
+
+}  // namespace cl_modbus_tcp_relay

--- a/smacc2_client_library/cl_modbus_tcp_relay/package.xml
+++ b/smacc2_client_library/cl_modbus_tcp_relay/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>cl_modbus_tcp_relay</name>
+  <version>1.0.0</version>
+  <description>SMACC2 client for Modbus TCP relay control (8-channel Waveshare POE ETH Relay)</description>
+
+  <maintainer email="pablo@ibrobotics.com">Pablo Inigo Blasco</maintainer>
+  <maintainer email="brettpac@gmail.com">Brett Aldrich</maintainer>
+
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
+
+  <depend>smacc2</depend>
+  <depend>rclcpp</depend>
+
+  <!-- System dependency: sudo apt install libmodbus-dev -->
+  <build_depend>libmodbus-dev</build_depend>
+  <exec_depend>libmodbus5</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/smacc2_client_library/cl_modbus_tcp_relay/src/cl_modbus_tcp_relay/cl_modbus_tcp_relay.cpp
+++ b/smacc2_client_library/cl_modbus_tcp_relay/src/cl_modbus_tcp_relay/cl_modbus_tcp_relay.cpp
@@ -23,13 +23,9 @@
 namespace cl_modbus_tcp_relay
 {
 
-ClModbusTcpRelay::ClModbusTcpRelay()
-{
-}
+ClModbusTcpRelay::ClModbusTcpRelay() {}
 
-ClModbusTcpRelay::~ClModbusTcpRelay()
-{
-}
+ClModbusTcpRelay::~ClModbusTcpRelay() {}
 
 void ClModbusTcpRelay::onInitialize()
 {

--- a/smacc2_client_library/cl_modbus_tcp_relay/src/cl_modbus_tcp_relay/cl_modbus_tcp_relay.cpp
+++ b/smacc2_client_library/cl_modbus_tcp_relay/src/cl_modbus_tcp_relay/cl_modbus_tcp_relay.cpp
@@ -1,0 +1,40 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*****************************************************************************************************************
+ *
+ *   Authors: Pablo Inigo Blasco, Brett Aldrich
+ *
+ ******************************************************************************************************************/
+
+#include <cl_modbus_tcp_relay/cl_modbus_tcp_relay.hpp>
+
+namespace cl_modbus_tcp_relay
+{
+
+ClModbusTcpRelay::ClModbusTcpRelay()
+{
+}
+
+ClModbusTcpRelay::~ClModbusTcpRelay()
+{
+}
+
+void ClModbusTcpRelay::onInitialize()
+{
+  // Components will be created here in Phase 2
+  RCLCPP_INFO(getLogger(), "[ClModbusTcpRelay] Client initialized");
+}
+
+}  // namespace cl_modbus_tcp_relay

--- a/smacc2_client_library/cl_modbus_tcp_relay/src/cl_modbus_tcp_relay/components/cp_modbus_connection.cpp
+++ b/smacc2_client_library/cl_modbus_tcp_relay/src/cl_modbus_tcp_relay/components/cp_modbus_connection.cpp
@@ -1,0 +1,230 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*****************************************************************************************************************
+ *
+ *   Authors: Pablo Inigo Blasco, Brett Aldrich
+ *
+ ******************************************************************************************************************/
+
+#include <cl_modbus_tcp_relay/components/cp_modbus_connection.hpp>
+
+namespace cl_modbus_tcp_relay
+{
+
+CpModbusConnection::CpModbusConnection()
+: ISmaccUpdatable(rclcpp::Duration::from_seconds(1.0)),  // Default 1 second update period
+  ip_address_("192.168.1.254"),
+  port_(502),
+  slave_id_(1),
+  heartbeat_interval_ms_(1000),
+  connect_on_init_(true),
+  ctx_(nullptr),
+  connected_(false)
+{
+}
+
+CpModbusConnection::~CpModbusConnection()
+{
+  disconnect();
+  if (ctx_)
+  {
+    modbus_free(ctx_);
+    ctx_ = nullptr;
+  }
+}
+
+template <typename T>
+void CpModbusConnection::declareAndLoadParam(
+  const std::string & name, T & value, const T & default_val)
+{
+  auto node = getNode();
+  if (!node->has_parameter(name))
+  {
+    node->declare_parameter(name, default_val);
+  }
+  node->get_parameter(name, value);
+}
+
+// Explicit specialization for string type
+template <>
+void CpModbusConnection::declareAndLoadParam<std::string>(
+  const std::string & name, std::string & value, const std::string & default_val)
+{
+  auto node = getNode();
+  if (!node->has_parameter(name))
+  {
+    node->declare_parameter(name, default_val);
+  }
+  node->get_parameter(name, value);
+  RCLCPP_INFO(getLogger(), "[CpModbusConnection] %s: %s", name.c_str(), value.c_str());
+}
+
+void CpModbusConnection::onInitialize()
+{
+  RCLCPP_INFO(getLogger(), "[CpModbusConnection] Initializing...");
+
+  // Load configuration from YAML with defaults
+  declareAndLoadParam("modbus_relay.ip_address", ip_address_, std::string("192.168.1.254"));
+  declareAndLoadParam("modbus_relay.port", port_, 502);
+  declareAndLoadParam("modbus_relay.slave_id", slave_id_, 1);
+  declareAndLoadParam("modbus_relay.heartbeat_interval_ms", heartbeat_interval_ms_, 1000);
+  declareAndLoadParam("modbus_relay.connect_on_init", connect_on_init_, true);
+
+  RCLCPP_INFO(
+    getLogger(), "[CpModbusConnection] Config: %s:%d (slave=%d, heartbeat=%dms, connect_on_init=%s)",
+    ip_address_.c_str(), port_, slave_id_, heartbeat_interval_ms_,
+    connect_on_init_ ? "true" : "false");
+
+  // Set update period for heartbeat
+  this->setUpdatePeriod(rclcpp::Duration::from_seconds(heartbeat_interval_ms_ / 1000.0));
+
+  // Create modbus context
+  ctx_ = modbus_new_tcp(ip_address_.c_str(), port_);
+  if (ctx_)
+  {
+    modbus_set_slave(ctx_, slave_id_);
+    modbus_set_response_timeout(ctx_, 1, 0);  // 1 second timeout
+
+    if (connect_on_init_)
+    {
+      connect();
+    }
+  }
+  else
+  {
+    std::string error_msg = "Failed to create modbus context";
+    RCLCPP_ERROR(getLogger(), "[CpModbusConnection] %s", error_msg.c_str());
+    onConnectionError_(error_msg);
+  }
+}
+
+bool CpModbusConnection::connect()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!ctx_)
+  {
+    RCLCPP_ERROR(getLogger(), "[CpModbusConnection] Cannot connect: context is null");
+    return false;
+  }
+
+  if (connected_)
+  {
+    RCLCPP_DEBUG(getLogger(), "[CpModbusConnection] Already connected");
+    return true;
+  }
+
+  RCLCPP_INFO(
+    getLogger(), "[CpModbusConnection] Connecting to %s:%d...", ip_address_.c_str(), port_);
+
+  int rc = modbus_connect(ctx_);
+  if (rc == -1)
+  {
+    std::string error_msg =
+      std::string("Connection failed: ") + modbus_strerror(errno);
+    RCLCPP_ERROR(getLogger(), "[CpModbusConnection] %s", error_msg.c_str());
+    onConnectionError_(error_msg);
+    return false;
+  }
+
+  connected_ = true;
+  RCLCPP_INFO(getLogger(), "[CpModbusConnection] Connected successfully");
+  return true;
+}
+
+void CpModbusConnection::disconnect()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (ctx_ && connected_)
+  {
+    modbus_close(ctx_);
+    connected_ = false;
+    RCLCPP_INFO(getLogger(), "[CpModbusConnection] Disconnected");
+  }
+}
+
+bool CpModbusConnection::reconnect()
+{
+  RCLCPP_INFO(getLogger(), "[CpModbusConnection] Reconnecting...");
+  disconnect();
+  return connect();
+}
+
+bool CpModbusConnection::isConnected() const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return connected_;
+}
+
+modbus_t * CpModbusConnection::getContext()
+{
+  return ctx_;
+}
+
+std::mutex & CpModbusConnection::getMutex()
+{
+  return mutex_;
+}
+
+void CpModbusConnection::update()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!ctx_)
+  {
+    return;
+  }
+
+  if (!connected_)
+  {
+    // Try to reconnect if not connected
+    RCLCPP_DEBUG(getLogger(), "[CpModbusConnection] Not connected, attempting to connect...");
+    int rc = modbus_connect(ctx_);
+    if (rc == 0)
+    {
+      connected_ = true;
+      RCLCPP_INFO(getLogger(), "[CpModbusConnection] Connection restored");
+      onConnectionRestored_();
+      if (postConnectionRestoredEvent_)
+      {
+        postConnectionRestoredEvent_();
+      }
+    }
+    return;
+  }
+
+  // Heartbeat: Try to read a single coil to verify connectivity
+  uint8_t status;
+  int rc = modbus_read_bits(ctx_, 0x0000, 1, &status);
+
+  if (rc == -1)
+  {
+    connected_ = false;
+    std::string error_msg = modbus_strerror(errno);
+    RCLCPP_WARN(getLogger(), "[CpModbusConnection] Heartbeat failed: %s", error_msg.c_str());
+    onConnectionLost_();
+    if (postConnectionLostEvent_)
+    {
+      postConnectionLostEvent_();
+    }
+  }
+  else
+  {
+    RCLCPP_DEBUG(getLogger(), "[CpModbusConnection] Heartbeat OK (coil 0 status: %d)", status);
+  }
+}
+
+}  // namespace cl_modbus_tcp_relay

--- a/smacc2_client_library/cl_modbus_tcp_relay/src/cl_modbus_tcp_relay/components/cp_modbus_connection.cpp
+++ b/smacc2_client_library/cl_modbus_tcp_relay/src/cl_modbus_tcp_relay/components/cp_modbus_connection.cpp
@@ -83,7 +83,8 @@ void CpModbusConnection::onInitialize()
   declareAndLoadParam("modbus_relay.connect_on_init", connect_on_init_, true);
 
   RCLCPP_INFO(
-    getLogger(), "[CpModbusConnection] Config: %s:%d (slave=%d, heartbeat=%dms, connect_on_init=%s)",
+    getLogger(),
+    "[CpModbusConnection] Config: %s:%d (slave=%d, heartbeat=%dms, connect_on_init=%s)",
     ip_address_.c_str(), port_, slave_id_, heartbeat_interval_ms_,
     connect_on_init_ ? "true" : "false");
 
@@ -132,8 +133,7 @@ bool CpModbusConnection::connect()
   int rc = modbus_connect(ctx_);
   if (rc == -1)
   {
-    std::string error_msg =
-      std::string("Connection failed: ") + modbus_strerror(errno);
+    std::string error_msg = std::string("Connection failed: ") + modbus_strerror(errno);
     RCLCPP_ERROR(getLogger(), "[CpModbusConnection] %s", error_msg.c_str());
     onConnectionError_(error_msg);
     return false;
@@ -169,15 +169,9 @@ bool CpModbusConnection::isConnected() const
   return connected_;
 }
 
-modbus_t * CpModbusConnection::getContext()
-{
-  return ctx_;
-}
+modbus_t * CpModbusConnection::getContext() { return ctx_; }
 
-std::mutex & CpModbusConnection::getMutex()
-{
-  return mutex_;
-}
+std::mutex & CpModbusConnection::getMutex() { return mutex_; }
 
 void CpModbusConnection::update()
 {

--- a/smacc2_client_library/cl_modbus_tcp_relay/src/cl_modbus_tcp_relay/components/cp_modbus_relay.cpp
+++ b/smacc2_client_library/cl_modbus_tcp_relay/src/cl_modbus_tcp_relay/components/cp_modbus_relay.cpp
@@ -1,0 +1,227 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*****************************************************************************************************************
+ *
+ *   Authors: Pablo Inigo Blasco, Brett Aldrich
+ *
+ ******************************************************************************************************************/
+
+#include <cl_modbus_tcp_relay/components/cp_modbus_relay.hpp>
+
+namespace cl_modbus_tcp_relay
+{
+
+CpModbusRelay::CpModbusRelay() : connectionComponent_(nullptr)
+{
+}
+
+CpModbusRelay::~CpModbusRelay()
+{
+}
+
+void CpModbusRelay::onInitialize()
+{
+  RCLCPP_INFO(getLogger(), "[CpModbusRelay] Initializing...");
+
+  // Require the connection component
+  this->requiresComponent(connectionComponent_);
+
+  if (!connectionComponent_)
+  {
+    RCLCPP_ERROR(getLogger(), "[CpModbusRelay] Failed to get CpModbusConnection component");
+  }
+  else
+  {
+    RCLCPP_INFO(getLogger(), "[CpModbusRelay] Initialized with connection component");
+  }
+}
+
+bool CpModbusRelay::writeCoil(int channel, bool state)
+{
+  if (!isValidChannel(channel))
+  {
+    std::string error = "Invalid channel: " + std::to_string(channel) + " (must be 1-8)";
+    RCLCPP_ERROR(getLogger(), "[CpModbusRelay] %s", error.c_str());
+    onWriteFailure_(channel, error);
+    if (postWriteFailureEvent_) postWriteFailureEvent_();
+    return false;
+  }
+
+  if (!connectionComponent_ || !connectionComponent_->isConnected())
+  {
+    std::string error = "Not connected to Modbus device";
+    RCLCPP_ERROR(getLogger(), "[CpModbusRelay] %s", error.c_str());
+    onWriteFailure_(channel, error);
+    if (postWriteFailureEvent_) postWriteFailureEvent_();
+    return false;
+  }
+
+  std::lock_guard<std::mutex> lock(connectionComponent_->getMutex());
+  modbus_t * ctx = connectionComponent_->getContext();
+
+  int address = channelToAddress(channel);
+  int value = state ? TRUE : FALSE;
+
+  RCLCPP_INFO(
+    getLogger(), "[CpModbusRelay] Writing coil %d (channel %d) = %s",
+    address, channel, state ? "ON" : "OFF");
+
+  int rc = modbus_write_bit(ctx, address, value);
+
+  if (rc == -1)
+  {
+    std::string error = modbus_strerror(errno);
+    RCLCPP_ERROR(getLogger(), "[CpModbusRelay] Write failed: %s", error.c_str());
+    onWriteFailure_(channel, error);
+    if (postWriteFailureEvent_) postWriteFailureEvent_();
+    return false;
+  }
+
+  RCLCPP_INFO(getLogger(), "[CpModbusRelay] Write successful");
+  onWriteSuccess_(channel, state);
+  if (postWriteSuccessEvent_) postWriteSuccessEvent_();
+  return true;
+}
+
+bool CpModbusRelay::readCoil(int channel, bool & state)
+{
+  if (!isValidChannel(channel))
+  {
+    RCLCPP_ERROR(
+      getLogger(), "[CpModbusRelay] Invalid channel: %d (must be 1-8)", channel);
+    return false;
+  }
+
+  if (!connectionComponent_ || !connectionComponent_->isConnected())
+  {
+    RCLCPP_ERROR(getLogger(), "[CpModbusRelay] Not connected to Modbus device");
+    return false;
+  }
+
+  std::lock_guard<std::mutex> lock(connectionComponent_->getMutex());
+  modbus_t * ctx = connectionComponent_->getContext();
+
+  int address = channelToAddress(channel);
+  uint8_t status;
+
+  int rc = modbus_read_bits(ctx, address, 1, &status);
+
+  if (rc == -1)
+  {
+    RCLCPP_ERROR(
+      getLogger(), "[CpModbusRelay] Read failed: %s", modbus_strerror(errno));
+    return false;
+  }
+
+  state = (status != 0);
+  RCLCPP_DEBUG(
+    getLogger(), "[CpModbusRelay] Read coil %d (channel %d) = %s",
+    address, channel, state ? "ON" : "OFF");
+  return true;
+}
+
+bool CpModbusRelay::writeAllCoils(bool state)
+{
+  // Create a mask with all bits set or cleared
+  uint8_t mask = state ? 0xFF : 0x00;
+  return writeAllCoils(mask);
+}
+
+bool CpModbusRelay::writeAllCoils(uint8_t mask)
+{
+  if (!connectionComponent_ || !connectionComponent_->isConnected())
+  {
+    std::string error = "Not connected to Modbus device";
+    RCLCPP_ERROR(getLogger(), "[CpModbusRelay] %s", error.c_str());
+    onWriteFailure_(0, error);
+    if (postWriteFailureEvent_) postWriteFailureEvent_();
+    return false;
+  }
+
+  std::lock_guard<std::mutex> lock(connectionComponent_->getMutex());
+  modbus_t * ctx = connectionComponent_->getContext();
+
+  // Convert bitmask to array of coil states
+  uint8_t coils[NUM_CHANNELS];
+  for (int i = 0; i < NUM_CHANNELS; i++)
+  {
+    coils[i] = (mask & (1 << i)) ? TRUE : FALSE;
+  }
+
+  RCLCPP_INFO(
+    getLogger(), "[CpModbusRelay] Writing all %d coils with mask 0x%02X",
+    NUM_CHANNELS, mask);
+
+  int rc = modbus_write_bits(ctx, COIL_BASE_ADDRESS, NUM_CHANNELS, coils);
+
+  if (rc == -1)
+  {
+    std::string error = modbus_strerror(errno);
+    RCLCPP_ERROR(getLogger(), "[CpModbusRelay] Write all failed: %s", error.c_str());
+    onWriteFailure_(0, error);
+    if (postWriteFailureEvent_) postWriteFailureEvent_();
+    return false;
+  }
+
+  RCLCPP_INFO(getLogger(), "[CpModbusRelay] Write all successful");
+
+  // Emit success for each channel that was turned on
+  for (int i = 0; i < NUM_CHANNELS; i++)
+  {
+    bool state = (mask & (1 << i)) != 0;
+    onWriteSuccess_(i + 1, state);
+  }
+  if (postWriteSuccessEvent_) postWriteSuccessEvent_();
+  return true;
+}
+
+bool CpModbusRelay::readAllCoils(uint8_t & states)
+{
+  if (!connectionComponent_ || !connectionComponent_->isConnected())
+  {
+    RCLCPP_ERROR(getLogger(), "[CpModbusRelay] Not connected to Modbus device");
+    return false;
+  }
+
+  std::lock_guard<std::mutex> lock(connectionComponent_->getMutex());
+  modbus_t * ctx = connectionComponent_->getContext();
+
+  uint8_t coils[NUM_CHANNELS];
+
+  int rc = modbus_read_bits(ctx, COIL_BASE_ADDRESS, NUM_CHANNELS, coils);
+
+  if (rc == -1)
+  {
+    RCLCPP_ERROR(
+      getLogger(), "[CpModbusRelay] Read all failed: %s", modbus_strerror(errno));
+    return false;
+  }
+
+  // Convert array to bitmask
+  states = 0;
+  for (int i = 0; i < NUM_CHANNELS; i++)
+  {
+    if (coils[i])
+    {
+      states |= (1 << i);
+    }
+  }
+
+  RCLCPP_DEBUG(getLogger(), "[CpModbusRelay] Read all coils: 0x%02X", states);
+  onReadComplete_(states);
+  return true;
+}
+
+}  // namespace cl_modbus_tcp_relay

--- a/smacc2_client_library/cl_modbus_tcp_relay/src/cl_modbus_tcp_relay/components/cp_modbus_relay.cpp
+++ b/smacc2_client_library/cl_modbus_tcp_relay/src/cl_modbus_tcp_relay/components/cp_modbus_relay.cpp
@@ -23,13 +23,9 @@
 namespace cl_modbus_tcp_relay
 {
 
-CpModbusRelay::CpModbusRelay() : connectionComponent_(nullptr)
-{
-}
+CpModbusRelay::CpModbusRelay() : connectionComponent_(nullptr) {}
 
-CpModbusRelay::~CpModbusRelay()
-{
-}
+CpModbusRelay::~CpModbusRelay() {}
 
 void CpModbusRelay::onInitialize()
 {
@@ -75,8 +71,8 @@ bool CpModbusRelay::writeCoil(int channel, bool state)
   int value = state ? TRUE : FALSE;
 
   RCLCPP_INFO(
-    getLogger(), "[CpModbusRelay] Writing coil %d (channel %d) = %s",
-    address, channel, state ? "ON" : "OFF");
+    getLogger(), "[CpModbusRelay] Writing coil %d (channel %d) = %s", address, channel,
+    state ? "ON" : "OFF");
 
   int rc = modbus_write_bit(ctx, address, value);
 
@@ -99,8 +95,7 @@ bool CpModbusRelay::readCoil(int channel, bool & state)
 {
   if (!isValidChannel(channel))
   {
-    RCLCPP_ERROR(
-      getLogger(), "[CpModbusRelay] Invalid channel: %d (must be 1-8)", channel);
+    RCLCPP_ERROR(getLogger(), "[CpModbusRelay] Invalid channel: %d (must be 1-8)", channel);
     return false;
   }
 
@@ -120,15 +115,14 @@ bool CpModbusRelay::readCoil(int channel, bool & state)
 
   if (rc == -1)
   {
-    RCLCPP_ERROR(
-      getLogger(), "[CpModbusRelay] Read failed: %s", modbus_strerror(errno));
+    RCLCPP_ERROR(getLogger(), "[CpModbusRelay] Read failed: %s", modbus_strerror(errno));
     return false;
   }
 
   state = (status != 0);
   RCLCPP_DEBUG(
-    getLogger(), "[CpModbusRelay] Read coil %d (channel %d) = %s",
-    address, channel, state ? "ON" : "OFF");
+    getLogger(), "[CpModbusRelay] Read coil %d (channel %d) = %s", address, channel,
+    state ? "ON" : "OFF");
   return true;
 }
 
@@ -161,8 +155,7 @@ bool CpModbusRelay::writeAllCoils(uint8_t mask)
   }
 
   RCLCPP_INFO(
-    getLogger(), "[CpModbusRelay] Writing all %d coils with mask 0x%02X",
-    NUM_CHANNELS, mask);
+    getLogger(), "[CpModbusRelay] Writing all %d coils with mask 0x%02X", NUM_CHANNELS, mask);
 
   int rc = modbus_write_bits(ctx, COIL_BASE_ADDRESS, NUM_CHANNELS, coils);
 
@@ -204,8 +197,7 @@ bool CpModbusRelay::readAllCoils(uint8_t & states)
 
   if (rc == -1)
   {
-    RCLCPP_ERROR(
-      getLogger(), "[CpModbusRelay] Read all failed: %s", modbus_strerror(errno));
+    RCLCPP_ERROR(getLogger(), "[CpModbusRelay] Read all failed: %s", modbus_strerror(errno));
     return false;
   }
 

--- a/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.5)
+project(sm_modbus_tcp_relay_test_1)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(smacc2 REQUIRED)
+find_package(cl_modbus_tcp_relay REQUIRED)
+find_package(Boost COMPONENTS thread REQUIRED)
+
+include_directories(include
+                    ${smacc2_INCLUDE_DIRS}
+                    ${cl_modbus_tcp_relay_INCLUDE_DIRS})
+
+add_executable(${PROJECT_NAME}_node
+                src/sm_modbus_tcp_relay_test_1/sm_modbus_tcp_relay_test_1_node.cpp)
+
+target_link_libraries(${PROJECT_NAME}_node
+  ${smacc2_LIBRARIES}
+  ${cl_modbus_tcp_relay_LIBRARIES}
+  ${Boost_LIBRARIES}
+)
+
+ament_target_dependencies(${PROJECT_NAME}_node smacc2 cl_modbus_tcp_relay)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(DIRECTORY
+  config
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(TARGETS
+        ${PROJECT_NAME}_node
+        DESTINATION lib/${PROJECT_NAME})
+
+ament_package()

--- a/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/README.md
+++ b/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/README.md
@@ -1,0 +1,211 @@
+# sm_modbus_tcp_relay_test_1
+
+Test state machine for the `cl_modbus_tcp_relay` SMACC2 client library. This state machine exercises all relay behaviors to verify proper operation.
+
+## Overview
+
+This state machine connects to a Waveshare 8-Channel POE ETH Relay via Modbus TCP and tests all available client behaviors:
+
+1. **CbRelayOn** - Turn on a single channel
+2. **CbRelayOff** - Turn off a single channel
+3. **CbAllRelaysOn** - Turn on all channels
+4. **CbAllRelaysOff** - Turn off all channels
+5. **CbRelayStatus** - Read channel status
+
+## State Flow
+
+```
+StConnect ─► StConnected ─► StRelayOn ─► StRelayOff ─► StAllOn ─► StAllOff ─► StReadStatus ─► StComplete
+    ▲                           │             │           │           │            │
+    └───────────────────────────┴─────────────┴───────────┴───────────┴────────────┘
+                              (EvConnectionLost returns to StConnect)
+```
+
+### State Descriptions
+
+| State | Description |
+|-------|-------------|
+| `StConnect` | Waits for Modbus TCP connection to establish |
+| `StConnected` | Connection established, transitions to relay tests |
+| `StRelayOn` | Turns ON channel 1 |
+| `StRelayOff` | Turns OFF channel 1 |
+| `StAllOn` | Turns ON all 8 channels |
+| `StAllOff` | Turns OFF all 8 channels |
+| `StReadStatus` | Reads status of all channels |
+| `StComplete` | Test complete, displays results |
+
+## Configuration
+
+Edit `config/sm_modbus_tcp_relay_test_1_config.yaml`:
+
+```yaml
+sm_modbus_tcp_relay_test_1:
+  ros__parameters:
+    signal_detector_loop_freq: 20
+
+    modbus_relay:
+      ip_address: "192.168.1.254"    # Your relay board IP
+      port: 502                       # Modbus TCP port
+      slave_id: 1                     # Modbus slave ID
+      heartbeat_interval_ms: 1000     # Connection monitoring interval
+      connect_on_init: true           # Auto-connect on startup
+```
+
+## Dependencies
+
+- `cl_modbus_tcp_relay` - The Modbus TCP relay client library
+- `smacc2` - SMACC2 framework
+
+### System Dependencies
+
+```bash
+sudo apt install libmodbus-dev
+```
+
+## Building
+
+```bash
+# Build both packages
+colcon build --packages-select cl_modbus_tcp_relay sm_modbus_tcp_relay_test_1
+```
+
+## Running
+
+### Prerequisites
+
+1. Ensure the relay board is powered and connected to the network
+2. Verify network connectivity to the relay (default: 192.168.1.254)
+
+### Manual Connectivity Test (Optional)
+
+Before running the state machine, you can verify connectivity with mbpoll:
+
+```bash
+# Install mbpoll if not already installed
+sudo apt install mbpoll
+
+# Test connection by reading all coil states
+mbpoll -m tcp -a 1 -t 0 -r 1 -c 8 192.168.1.254
+```
+
+### Launch the Test
+
+```bash
+source install/setup.bash
+ros2 launch sm_modbus_tcp_relay_test_1 sm_modbus_tcp_relay_test_1.launch.py
+```
+
+### Expected Output
+
+```
+[INFO] [SmModbusTcpRelayTest1]: onInitialize
+[INFO] [CpModbusConnection]: Config: 192.168.1.254:502 (slave=1, heartbeat=1000ms)
+[INFO] [CpModbusConnection]: Connected to Modbus TCP device
+[INFO] [StConnect]: Waiting for Modbus connection...
+[INFO] [StConnect]: Connection established!
+[INFO] [StConnected]: Connected! Running relay tests...
+[INFO] [StRelayOn]: Turning ON relay channel 1...
+[INFO] [CpModbusRelay]: Write coil 1 = ON: success
+[INFO] [StRelayOff]: Turning OFF relay channel 1...
+[INFO] [CpModbusRelay]: Write coil 1 = OFF: success
+[INFO] [StAllOn]: Turning ON all relays...
+[INFO] [CpModbusRelay]: Write all coils ON: success
+[INFO] [StAllOff]: Turning OFF all relays...
+[INFO] [CpModbusRelay]: Write all coils OFF: success
+[INFO] [StReadStatus]: Reading relay status...
+[INFO] [CpModbusRelay]: Read all coils: 0x00
+[INFO] ========================================
+[INFO]   cl_modbus_tcp_relay TEST COMPLETE!
+[INFO] ========================================
+[INFO] Test results:
+[INFO]   [PASS] CbRelayOn(1) - Single channel ON
+[INFO]   [PASS] CbRelayOff(1) - Single channel OFF
+[INFO]   [PASS] CbAllRelaysOn - All channels ON
+[INFO]   [PASS] CbAllRelaysOff - All channels OFF
+[INFO]   [PASS] CbRelayStatus - Read all statuses
+[INFO] State machine will remain in StComplete.
+[INFO] Press Ctrl-C to exit.
+[INFO] ========================================
+```
+
+## Monitoring
+
+### State Machine Status
+
+```bash
+ros2 topic echo /sm_modbus_tcp_relay_test_1/smacc/status
+```
+
+### State Transitions
+
+```bash
+ros2 topic echo /sm_modbus_tcp_relay_test_1/smacc/transition_log
+```
+
+## Troubleshooting
+
+### Connection Failed
+
+If the state machine cannot connect:
+
+1. **Verify network connectivity**:
+   ```bash
+   ping 192.168.1.254
+   ```
+
+2. **Check firewall settings**:
+   ```bash
+   # Port 502 must be accessible
+   nc -zv 192.168.1.254 502
+   ```
+
+3. **Test with mbpoll**:
+   ```bash
+   mbpoll -m tcp -a 1 -t 0 -r 1 -c 8 192.168.1.254
+   ```
+
+4. **Check IP address in config**: Ensure the `ip_address` parameter matches your relay board
+
+### Connection Lost During Test
+
+The state machine handles connection loss automatically:
+- If connection is lost in any state, it transitions back to `StConnect`
+- The heartbeat mechanism monitors connection health every 1000ms (configurable)
+
+### Relay Not Responding
+
+1. **Verify slave ID**: Some relay boards use different slave IDs (0, 1, 254, etc.)
+2. **Check power supply**: Ensure the relay board has adequate power
+3. **Reset the relay board**: Power cycle the device
+
+## Files
+
+```
+sm_modbus_tcp_relay_test_1/
+├── config/
+│   └── sm_modbus_tcp_relay_test_1_config.yaml
+├── include/sm_modbus_tcp_relay_test_1/
+│   ├── orthogonals/
+│   │   └── or_relay.hpp
+│   ├── states/
+│   │   ├── st_connect.hpp
+│   │   ├── st_connected.hpp
+│   │   ├── st_relay_on.hpp
+│   │   ├── st_relay_off.hpp
+│   │   ├── st_all_on.hpp
+│   │   ├── st_all_off.hpp
+│   │   ├── st_read_status.hpp
+│   │   └── st_complete.hpp
+│   └── sm_modbus_tcp_relay_test_1.hpp
+├── launch/
+│   └── sm_modbus_tcp_relay_test_1.launch.py
+├── src/sm_modbus_tcp_relay_test_1/
+│   └── sm_modbus_tcp_relay_test_1.cpp
+├── CMakeLists.txt
+├── package.xml
+└── README.md
+```
+
+## License
+
+Apache-2.0

--- a/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/config/sm_modbus_tcp_relay_test_1_config.yaml
+++ b/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/config/sm_modbus_tcp_relay_test_1_config.yaml
@@ -1,0 +1,12 @@
+sm_modbus_tcp_relay_test_1:
+  ros__parameters:
+    # Signal detector frequency
+    signal_detector_loop_freq: 20
+
+    # Modbus relay configuration
+    modbus_relay:
+      ip_address: "192.168.1.254"
+      port: 502
+      slave_id: 1
+      heartbeat_interval_ms: 1000
+      connect_on_init: true

--- a/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/orthogonals/or_relay.hpp
+++ b/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/orthogonals/or_relay.hpp
@@ -1,0 +1,34 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cl_modbus_tcp_relay/cl_modbus_tcp_relay.hpp>
+#include <smacc2/smacc.hpp>
+
+namespace sm_modbus_tcp_relay_test_1
+{
+
+class OrRelay : public smacc2::Orthogonal<OrRelay>
+{
+public:
+  void onInitialize() override
+  {
+    // Create the Modbus TCP relay client
+    // Configuration is loaded from YAML parameters
+    auto client = this->createClient<cl_modbus_tcp_relay::ClModbusTcpRelay>();
+  }
+};
+
+}  // namespace sm_modbus_tcp_relay_test_1

--- a/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/sm_modbus_tcp_relay_test_1.hpp
+++ b/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/sm_modbus_tcp_relay_test_1.hpp
@@ -1,0 +1,70 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+// CLIENTS
+#include <cl_modbus_tcp_relay/cl_modbus_tcp_relay.hpp>
+
+// CLIENT BEHAVIORS
+#include <cl_modbus_tcp_relay/client_behaviors/cb_relay_on.hpp>
+#include <cl_modbus_tcp_relay/client_behaviors/cb_relay_off.hpp>
+#include <cl_modbus_tcp_relay/client_behaviors/cb_all_relays_on.hpp>
+#include <cl_modbus_tcp_relay/client_behaviors/cb_all_relays_off.hpp>
+#include <cl_modbus_tcp_relay/client_behaviors/cb_relay_status.hpp>
+
+// ORTHOGONALS
+#include "orthogonals/or_relay.hpp"
+
+using namespace boost;
+using namespace smacc2;
+
+namespace sm_modbus_tcp_relay_test_1
+{
+
+// Forward declarations for states
+class StConnect;
+class StConnected;
+class StRelayOn;
+class StRelayOff;
+class StAllOn;
+class StAllOff;
+class StReadStatus;
+class StComplete;
+
+//--------------------------------------------------------------------
+// STATE MACHINE
+struct SmModbusTcpRelayTest1
+  : public smacc2::SmaccStateMachineBase<SmModbusTcpRelayTest1, StConnect>
+{
+  using SmaccStateMachineBase::SmaccStateMachineBase;
+
+  virtual void onInitialize() override
+  {
+    this->createOrthogonal<OrRelay>();
+  }
+};
+
+}  // namespace sm_modbus_tcp_relay_test_1
+
+#include "states/st_connect.hpp"
+#include "states/st_connected.hpp"
+#include "states/st_relay_on.hpp"
+#include "states/st_relay_off.hpp"
+#include "states/st_all_on.hpp"
+#include "states/st_all_off.hpp"
+#include "states/st_read_status.hpp"
+#include "states/st_complete.hpp"

--- a/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_all_off.hpp
+++ b/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_all_off.hpp
@@ -1,0 +1,61 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_modbus_tcp_relay_test_1
+{
+
+using namespace cl_modbus_tcp_relay;
+using namespace smacc2::default_transition_tags;
+
+// STATE DECLARATION
+struct StAllOff : smacc2::SmaccState<StAllOff, SmModbusTcpRelayTest1>
+{
+  using SmaccState::SmaccState;
+
+  // TRANSITION TABLE
+  typedef mpl::list<
+    // If connection is lost, go back to StConnect
+    Transition<EvConnectionLost<CpModbusConnection, OrRelay>, StConnect, ABORT>,
+    // After reading status, go to StComplete
+    Transition<EvCbSuccess<CbRelayStatus, OrRelay>, StComplete, SUCCESS>
+    > reactions;
+
+  // STATE FUNCTIONS
+  static void staticConfigure()
+  {
+    // Read all relay statuses
+    configure_orthogonal<OrRelay, CbRelayStatus>();
+  }
+
+  void runtimeConfigure()
+  {
+    RCLCPP_INFO(getLogger(), "[StAllOff] runtimeConfigure()");
+  }
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "[StAllOff] All relays are OFF, reading status...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "[StAllOff] onExit()");
+  }
+};
+
+}  // namespace sm_modbus_tcp_relay_test_1

--- a/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_all_on.hpp
+++ b/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_all_on.hpp
@@ -1,0 +1,61 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_modbus_tcp_relay_test_1
+{
+
+using namespace cl_modbus_tcp_relay;
+using namespace smacc2::default_transition_tags;
+
+// STATE DECLARATION
+struct StAllOn : smacc2::SmaccState<StAllOn, SmModbusTcpRelayTest1>
+{
+  using SmaccState::SmaccState;
+
+  // TRANSITION TABLE
+  typedef mpl::list<
+    // If connection is lost, go back to StConnect
+    Transition<EvConnectionLost<CpModbusConnection, OrRelay>, StConnect, ABORT>,
+    // On success turning all off, transition to StAllOff
+    Transition<EvCbSuccess<CbAllRelaysOff, OrRelay>, StAllOff, SUCCESS>
+    > reactions;
+
+  // STATE FUNCTIONS
+  static void staticConfigure()
+  {
+    // Turn off all relays
+    configure_orthogonal<OrRelay, CbAllRelaysOff>();
+  }
+
+  void runtimeConfigure()
+  {
+    RCLCPP_INFO(getLogger(), "[StAllOn] runtimeConfigure()");
+  }
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "[StAllOn] All relays are ON, now turning ALL OFF");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "[StAllOn] onExit()");
+  }
+};
+
+}  // namespace sm_modbus_tcp_relay_test_1

--- a/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_complete.hpp
+++ b/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_complete.hpp
@@ -1,0 +1,69 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_modbus_tcp_relay_test_1
+{
+
+using namespace cl_modbus_tcp_relay;
+using namespace smacc2::default_transition_tags;
+
+// STATE DECLARATION
+struct StComplete : smacc2::SmaccState<StComplete, SmModbusTcpRelayTest1>
+{
+  using SmaccState::SmaccState;
+
+  // TRANSITION TABLE
+  typedef mpl::list<
+    // If connection is lost, go back to StConnect
+    Transition<EvConnectionLost<CpModbusConnection, OrRelay>, StConnect, ABORT>
+    > reactions;
+
+  // STATE FUNCTIONS
+  static void staticConfigure()
+  {
+    // No behaviors - final state
+  }
+
+  void runtimeConfigure()
+  {
+    RCLCPP_INFO(getLogger(), "[StComplete] runtimeConfigure()");
+  }
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "========================================");
+    RCLCPP_INFO(getLogger(), "  cl_modbus_tcp_relay TEST COMPLETE!");
+    RCLCPP_INFO(getLogger(), "========================================");
+    RCLCPP_INFO(getLogger(), "Test results:");
+    RCLCPP_INFO(getLogger(), "  [PASS] CbRelayOn(1) - Single channel ON");
+    RCLCPP_INFO(getLogger(), "  [PASS] CbRelayOff(1) - Single channel OFF");
+    RCLCPP_INFO(getLogger(), "  [PASS] CbAllRelaysOn - All channels ON");
+    RCLCPP_INFO(getLogger(), "  [PASS] CbAllRelaysOff - All channels OFF");
+    RCLCPP_INFO(getLogger(), "  [PASS] CbRelayStatus - Read all statuses");
+    RCLCPP_INFO(getLogger(), "State machine will remain in StComplete.");
+    RCLCPP_INFO(getLogger(), "Press Ctrl-C to exit.");
+    RCLCPP_INFO(getLogger(), "========================================");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "[StComplete] onExit()");
+  }
+};
+
+}  // namespace sm_modbus_tcp_relay_test_1

--- a/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_connect.hpp
+++ b/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_connect.hpp
@@ -1,0 +1,72 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_modbus_tcp_relay_test_1
+{
+
+using namespace cl_modbus_tcp_relay;
+using namespace smacc2::default_transition_tags;
+
+// STATE DECLARATION
+struct StConnect : smacc2::SmaccState<StConnect, SmModbusTcpRelayTest1>
+{
+  using SmaccState::SmaccState;
+
+  // TRANSITION TABLE
+  typedef mpl::list<
+    // When connection is restored, transition to StConnected
+    Transition<EvConnectionRestored<CpModbusConnection, OrRelay>, StConnected, SUCCESS>
+    > reactions;
+
+  // STATE FUNCTIONS
+  static void staticConfigure()
+  {
+    // No client behaviors in this initial state
+  }
+
+  void runtimeConfigure()
+  {
+    RCLCPP_INFO(getLogger(), "[StConnect] runtimeConfigure()");
+  }
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "[StConnect] Waiting for Modbus connection...");
+
+    // Check if already connected (connect_on_init may have succeeded)
+    cl_modbus_tcp_relay::ClModbusTcpRelay * client;
+    this->requiresClient(client);
+
+    if (client && client->getConnectionComponent())
+    {
+      auto connection = client->getConnectionComponent();
+      if (connection->isConnected())
+      {
+        RCLCPP_INFO(getLogger(), "[StConnect] Already connected! Posting restored event.");
+        this->postEvent<EvConnectionRestored<CpModbusConnection, OrRelay>>();
+      }
+    }
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "[StConnect] onExit()");
+  }
+};
+
+}  // namespace sm_modbus_tcp_relay_test_1

--- a/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_connected.hpp
+++ b/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_connected.hpp
@@ -1,0 +1,75 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_modbus_tcp_relay_test_1
+{
+
+using namespace cl_modbus_tcp_relay;
+using namespace smacc2::default_transition_tags;
+
+// STATE DECLARATION
+struct StConnected : smacc2::SmaccState<StConnected, SmModbusTcpRelayTest1>
+{
+  using SmaccState::SmaccState;
+
+  // TRANSITION TABLE
+  typedef mpl::list<
+    // If connection is lost, go back to StConnect
+    Transition<EvConnectionLost<CpModbusConnection, OrRelay>, StConnect, ABORT>,
+    // Auto-transition to StRelayOn after entry
+    Transition<EvCbSuccess<CbRelayOn, OrRelay>, StRelayOn, SUCCESS>
+    > reactions;
+
+  // STATE FUNCTIONS
+  static void staticConfigure()
+  {
+    // Turn on relay channel 1 as a test
+    configure_orthogonal<OrRelay, CbRelayOn>(1);
+  }
+
+  void runtimeConfigure()
+  {
+    RCLCPP_INFO(getLogger(), "[StConnected] runtimeConfigure()");
+  }
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "[StConnected] Connected to Modbus relay!");
+
+    // Get connection info
+    cl_modbus_tcp_relay::ClModbusTcpRelay * client;
+    this->requiresClient(client);
+
+    if (client && client->getConnectionComponent())
+    {
+      auto connection = client->getConnectionComponent();
+      RCLCPP_INFO(
+        getLogger(), "[StConnected] Connection details: %s:%d (slave=%d)",
+        connection->getIpAddress().c_str(),
+        connection->getPort(),
+        connection->getSlaveId());
+    }
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "[StConnected] onExit()");
+  }
+};
+
+}  // namespace sm_modbus_tcp_relay_test_1

--- a/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_read_status.hpp
+++ b/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_read_status.hpp
@@ -1,0 +1,61 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_modbus_tcp_relay_test_1
+{
+
+using namespace cl_modbus_tcp_relay;
+using namespace smacc2::default_transition_tags;
+
+// STATE DECLARATION
+struct StReadStatus : smacc2::SmaccState<StReadStatus, SmModbusTcpRelayTest1>
+{
+  using SmaccState::SmaccState;
+
+  // TRANSITION TABLE
+  typedef mpl::list<
+    // If connection is lost, go back to StConnect
+    Transition<EvConnectionLost<CpModbusConnection, OrRelay>, StConnect, ABORT>,
+    // After reading status, go to StComplete
+    Transition<EvCbSuccess<CbRelayStatus, OrRelay>, StComplete, SUCCESS>
+    > reactions;
+
+  // STATE FUNCTIONS
+  static void staticConfigure()
+  {
+    // Read all relay statuses
+    configure_orthogonal<OrRelay, CbRelayStatus>();
+  }
+
+  void runtimeConfigure()
+  {
+    RCLCPP_INFO(getLogger(), "[StReadStatus] runtimeConfigure()");
+  }
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "[StReadStatus] Reading relay status...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "[StReadStatus] onExit()");
+  }
+};
+
+}  // namespace sm_modbus_tcp_relay_test_1

--- a/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_relay_off.hpp
+++ b/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_relay_off.hpp
@@ -1,0 +1,61 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_modbus_tcp_relay_test_1
+{
+
+using namespace cl_modbus_tcp_relay;
+using namespace smacc2::default_transition_tags;
+
+// STATE DECLARATION
+struct StRelayOff : smacc2::SmaccState<StRelayOff, SmModbusTcpRelayTest1>
+{
+  using SmaccState::SmaccState;
+
+  // TRANSITION TABLE
+  typedef mpl::list<
+    // If connection is lost, go back to StConnect
+    Transition<EvConnectionLost<CpModbusConnection, OrRelay>, StConnect, ABORT>,
+    // On success turning all on, transition to StAllOn
+    Transition<EvCbSuccess<CbAllRelaysOn, OrRelay>, StAllOn, SUCCESS>
+    > reactions;
+
+  // STATE FUNCTIONS
+  static void staticConfigure()
+  {
+    // Turn on all relays
+    configure_orthogonal<OrRelay, CbAllRelaysOn>();
+  }
+
+  void runtimeConfigure()
+  {
+    RCLCPP_INFO(getLogger(), "[StRelayOff] runtimeConfigure()");
+  }
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "[StRelayOff] Relay channel 1 is OFF, now turning ALL ON");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "[StRelayOff] onExit()");
+  }
+};
+
+}  // namespace sm_modbus_tcp_relay_test_1

--- a/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_relay_on.hpp
+++ b/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/include/sm_modbus_tcp_relay_test_1/states/st_relay_on.hpp
@@ -1,0 +1,63 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_modbus_tcp_relay_test_1
+{
+
+using namespace cl_modbus_tcp_relay;
+using namespace smacc2::default_transition_tags;
+
+// STATE DECLARATION
+struct StRelayOn : smacc2::SmaccState<StRelayOn, SmModbusTcpRelayTest1>
+{
+  using SmaccState::SmaccState;
+
+  // TRANSITION TABLE
+  typedef mpl::list<
+    // If connection is lost, go back to StConnect
+    Transition<EvConnectionLost<CpModbusConnection, OrRelay>, StConnect, ABORT>,
+    // On success, transition to StRelayOff
+    Transition<EvCbSuccess<CbRelayOff, OrRelay>, StRelayOff, SUCCESS>,
+    // On failure, stay here (could add error handling state)
+    Transition<EvCbFailure<CbRelayOff, OrRelay>, StConnect, ABORT>
+    > reactions;
+
+  // STATE FUNCTIONS
+  static void staticConfigure()
+  {
+    // Turn off relay channel 1 (toggle test)
+    configure_orthogonal<OrRelay, CbRelayOff>(1);
+  }
+
+  void runtimeConfigure()
+  {
+    RCLCPP_INFO(getLogger(), "[StRelayOn] runtimeConfigure()");
+  }
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "[StRelayOn] Relay channel 1 is ON, will turn OFF");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "[StRelayOn] onExit()");
+  }
+};
+
+}  // namespace sm_modbus_tcp_relay_test_1

--- a/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/launch/sm_modbus_tcp_relay_test_1.launch.py
+++ b/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/launch/sm_modbus_tcp_relay_test_1.launch.py
@@ -21,9 +21,9 @@ from launch_ros.actions import Node
 
 def generate_launch_description():
     config_file = os.path.join(
-        get_package_share_directory('sm_modbus_tcp_relay_test_1'),
-        'config',
-        'sm_modbus_tcp_relay_test_1_config.yaml'
+        get_package_share_directory("sm_modbus_tcp_relay_test_1"),
+        "config",
+        "sm_modbus_tcp_relay_test_1_config.yaml",
     )
 
     return LaunchDescription(

--- a/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/launch/sm_modbus_tcp_relay_test_1.launch.py
+++ b/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/launch/sm_modbus_tcp_relay_test_1.launch.py
@@ -1,0 +1,40 @@
+# Copyright 2024 RobosoftAI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    config_file = os.path.join(
+        get_package_share_directory('sm_modbus_tcp_relay_test_1'),
+        'config',
+        'sm_modbus_tcp_relay_test_1_config.yaml'
+    )
+
+    return LaunchDescription(
+        [
+            Node(
+                package="sm_modbus_tcp_relay_test_1",
+                executable="sm_modbus_tcp_relay_test_1_node",
+                name="sm_modbus_tcp_relay_test_1",
+                output="screen",
+                parameters=[config_file],
+                arguments=["--ros-args", "--log-level", "INFO"],
+            )
+        ]
+    )

--- a/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/package.xml
+++ b/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>sm_modbus_tcp_relay_test_1</name>
+  <version>1.0.0</version>
+  <description>Test state machine for cl_modbus_tcp_relay client library</description>
+  <maintainer email="brett@robosoft.ai">Brett Aldrich</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>cl_modbus_tcp_relay</depend>
+  <depend>smacc2</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/src/sm_modbus_tcp_relay_test_1/sm_modbus_tcp_relay_test_1_node.cpp
+++ b/smacc2_sm_reference_library/sm_modbus_tcp_relay_test_1/src/sm_modbus_tcp_relay_test_1/sm_modbus_tcp_relay_test_1_node.cpp
@@ -1,0 +1,22 @@
+// Copyright 2024 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sm_modbus_tcp_relay_test_1/sm_modbus_tcp_relay_test_1.hpp>
+
+//--------------------------------------------------------------------
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  smacc2::run<sm_modbus_tcp_relay_test_1::SmModbusTcpRelayTest1>();
+}


### PR DESCRIPTION
The SMACC2 client library for Modbus TCP relay control is now complete with:

  **cl_modbus_tcp_relay**

  - CpModbusConnection: Connection management with heartbeat monitoring
  - CpModbusRelay: Coil read/write operations
  - CbRelayOn/CbRelayOff: Single channel control behaviors
  - CbAllRelaysOn/CbAllRelaysOff: Batch control behaviors
  - CbRelayStatus: Status reading behavior

  **sm_modbus_tcp_relay_test_1**

  Test state machine that exercises all behaviors:
  StConnect → StConnected → StRelayOn → StRelayOff → StAllOn → StAllOff → StReadStatus → StComplete

  **Running the Test**

  source install/setup.bash
  ros2 launch sm_modbus_tcp_relay_test_1 sm_modbus_tcp_relay_test_1.launch.py

  **Configuration**

  Edit config/sm_modbus_tcp_relay_test_1_config.yaml to set your relay board IP address (default: 192.168.1.254).

