### PR TITLE
New set of behaviors for cl_px4_mr and new state machine sm_cl_px4_mr_test_2

### DIFF
--- a/smacc2/include/smacc2/client_core_components/cp_subprocess_executor.hpp
+++ b/smacc2/include/smacc2/client_core_components/cp_subprocess_executor.hpp
@@ -23,6 +23,7 @@
 #include <smacc2/common.hpp>
 #include <smacc2/component.hpp>
 #include <smacc2/smacc_signal.hpp>
+#include <smacc2/smacc_state_machine.hpp>
 
 namespace smacc2
 {

--- a/smacc2_client_library/cl_px4_mr/CMakeLists.txt
+++ b/smacc2_client_library/cl_px4_mr/CMakeLists.txt
@@ -37,6 +37,13 @@ set(SOURCES
   src/cl_px4_mr/client_behaviors/cb_land.cpp
   src/cl_px4_mr/client_behaviors/cb_go_to_location.cpp
   src/cl_px4_mr/client_behaviors/cb_orbit_location.cpp
+  src/cl_px4_mr/client_behaviors/cb_hold_position.cpp
+  src/cl_px4_mr/client_behaviors/cb_yaw_rotate.cpp
+  src/cl_px4_mr/client_behaviors/cb_change_altitude.cpp
+  src/cl_px4_mr/client_behaviors/cb_follow_waypoints.cpp
+  src/cl_px4_mr/client_behaviors/cb_figure_eight.cpp
+  src/cl_px4_mr/client_behaviors/cb_return_to_home.cpp
+  src/cl_px4_mr/client_behaviors/cb_spiral_pattern.cpp
 )
 
 add_library(${PROJECT_NAME} ${SOURCES})

--- a/smacc2_client_library/cl_px4_mr/README.md
+++ b/smacc2_client_library/cl_px4_mr/README.md
@@ -91,7 +91,7 @@ CpVehicleLocalPosition  → onPositionReceived_
 CpVehicleCommandAck     → onAckReceived_
 CpGoalChecker (update)  → onGoalReached_
     ↓ (signal connections)
-Client Behaviors (CbArmPX4, CbTakeOff, CbLand, etc.)
+Client Behaviors (CbArmPX4, CbTakeOff, CbLand, CbHoldPosition, CbFollowWaypoints, etc.)
     ↓ (postSuccessEvent / postFailureEvent)
 State Machine Transitions
 ```
@@ -116,6 +116,13 @@ PX4 SITL (via XRCE-DDS)
 | CbGoToLocation | SmaccAsyncClientBehavior | Fly to NED position | `targetX`, `targetY`, `targetZ`, `yaw` (optional) |
 | CbOrbitLocation | SmaccAsyncClientBehavior + ISmaccUpdatable | Orbit a center point | `centerX`, `centerY`, `altitude`, `radius`, `angularVelocity`, `numOrbits` |
 | CbLand | SmaccAsyncClientBehavior | Disable offboard and land | None (detects landing via disarm signal) |
+| CbHoldPosition | SmaccAsyncClientBehavior + ISmaccUpdatable | Hold current position for a duration | `durationSeconds` (default 5.0) |
+| CbYawRotate | SmaccAsyncClientBehavior + ISmaccUpdatable | Rotate to a target heading | `targetYawRad`, `relative` (default false) |
+| CbChangeAltitude | SmaccAsyncClientBehavior | Ascend or descend to a target altitude | `targetAltitude` (positive meters above ground) |
+| CbFollowWaypoints | SmaccAsyncClientBehavior | Visit a sequence of NED waypoints | `waypoints` (vector of {x,y,z,yaw}), `xyTol` (0.5), `zTol` (0.3) |
+| CbFigureEight | SmaccAsyncClientBehavior + ISmaccUpdatable | Fly a lemniscate figure-8 pattern | `centerX`, `centerY`, `altitude`, `size` (5.0), `speed` (0.5), `numLoops` (1) |
+| CbReturnToHome | SmaccAsyncClientBehavior | Return to a specified home position | `homeX`, `homeY`, `homeZ`, `homeYaw` |
+| CbSpiralPattern | SmaccAsyncClientBehavior + ISmaccUpdatable | Fly an expanding Archimedean spiral (search & rescue) | `centerX`, `centerY`, `altitude`, `maxRadius` (20.0), `spacing` (3.0), `speed` (2.0) |
 
 ### CbArmPX4
 
@@ -148,6 +155,58 @@ Landing sequence:
 1. Disable offboard keepalive
 2. Send land command
 3. Posts `EvCbSuccess` when vehicle disarms (PX4 auto-disarms after touchdown)
+
+### CbHoldPosition
+
+Hold current position for a specified duration:
+- Calls `CpTrajectorySetpoint::hold()` to lock current position
+- Uses `ISmaccUpdatable::update()` to monitor elapsed time
+- Posts `EvCbSuccess` when duration reached
+
+### CbYawRotate
+
+Rotate in place to a target heading:
+- Supports absolute or relative yaw targets
+- Commands position setpoint with new yaw at current XY/Z
+- Monitors heading convergence (within ~0.1 rad tolerance)
+- Posts `EvCbSuccess` when target heading reached
+
+### CbChangeAltitude
+
+Ascend or descend to a target altitude while maintaining XY position:
+- Gets current XY and heading, sends setpoint with new Z = `-targetAltitude`
+- Uses `CpGoalChecker` signal for completion detection
+- Posts `EvCbSuccess` when altitude reached
+
+### CbFollowWaypoints
+
+Visit a sequence of NED waypoints in order:
+- Each waypoint is `{x, y, z, yaw}` — yaw = NaN to maintain current heading
+- Advances to next waypoint on each `CpGoalChecker::onGoalReached_` callback
+- Posts `EvCbSuccess` after the last waypoint is reached
+
+### CbFigureEight
+
+Fly a figure-8 (lemniscate of Bernoulli) pattern:
+- Parametric equations trace a lemniscate centered at the given point
+- Yaw faces direction of travel via derivatives
+- Uses `ISmaccUpdatable::update()` for continuous trajectory streaming
+- Posts `EvCbSuccess` after completing `numLoops` full loops
+
+### CbReturnToHome
+
+Return to a stored home position:
+- Home coordinates passed explicitly by the state machine
+- Uses `CpGoalChecker` signal for completion detection
+- Posts `EvCbSuccess` when home position reached
+
+### CbSpiralPattern
+
+Fly an expanding Archimedean spiral for search and rescue area coverage:
+- `r(θ) = (spacing / 2π) × θ` — each revolution expands radius by `spacing` meters
+- Adaptive angular velocity maintains constant linear ground speed
+- Yaw faces direction of travel
+- Posts `EvCbSuccess` when `maxRadius` is reached
 
 ## Usage
 
@@ -247,10 +306,16 @@ PX4 uses NED (North-East-Down): altitude of 5m above ground = z = -5.0
 
 ## Testing
 
-Run the reference state machine:
+Two reference state machines are available:
 
+**sm_cl_px4_mr_test_1** — Basic flight: arm, takeoff, go-to, orbit, return, land.
 ```bash
 ros2 launch sm_cl_px4_mr_test_1 sm_cl_px4_mr_test_1.launch.py
+```
+
+**sm_cl_px4_mr_test_2** — Extended behaviors: hold position, yaw rotate, change altitude, spiral pattern, follow waypoints, figure-eight, return to home.
+```bash
+ros2 launch sm_cl_px4_mr_test_2 sm_cl_px4_mr_test_2.launch.py
 ```
 
 See [sm_cl_px4_mr_test_1 README](../../smacc2_sm_reference_library/sm_cl_px4_mr_test_1/README.md) for full launch instructions.

--- a/smacc2_client_library/cl_px4_mr/include/cl_px4_mr/client_behaviors/cb_change_altitude.hpp
+++ b/smacc2_client_library/cl_px4_mr/include/cl_px4_mr/client_behaviors/cb_change_altitude.hpp
@@ -1,0 +1,43 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace cl_px4_mr
+{
+
+class CpTrajectorySetpoint;
+class CpGoalChecker;
+class CpVehicleLocalPosition;
+
+class CbChangeAltitude : public smacc2::SmaccAsyncClientBehavior
+{
+public:
+  explicit CbChangeAltitude(float targetAltitude);
+
+  void onEntry() override;
+  void onExit() override;
+
+private:
+  void onGoalReachedCallback();
+
+  float targetAltitude_;
+  CpTrajectorySetpoint * trajectorySetpoint_ = nullptr;
+  CpGoalChecker * goalChecker_ = nullptr;
+  CpVehicleLocalPosition * localPosition_ = nullptr;
+};
+
+}  // namespace cl_px4_mr

--- a/smacc2_client_library/cl_px4_mr/include/cl_px4_mr/client_behaviors/cb_figure_eight.hpp
+++ b/smacc2_client_library/cl_px4_mr/include/cl_px4_mr/client_behaviors/cb_figure_eight.hpp
@@ -1,0 +1,51 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <chrono>
+#include <cmath>
+#include <smacc2/smacc.hpp>
+
+namespace cl_px4_mr
+{
+
+class CpTrajectorySetpoint;
+
+class CbFigureEight : public smacc2::SmaccAsyncClientBehavior, public smacc2::ISmaccUpdatable
+{
+public:
+  CbFigureEight(
+    float centerX, float centerY, float altitude, float size = 5.0f, float speed = 0.5f,
+    int numLoops = 1);
+
+  void onEntry() override;
+  void onExit() override;
+  void update() override;
+
+private:
+  float centerX_;
+  float centerY_;
+  float altitude_;
+  float size_;
+  float speed_;
+  int numLoops_;
+
+  float t_ = 0.0f;
+  std::chrono::steady_clock::time_point lastUpdateTime_;
+
+  CpTrajectorySetpoint * trajectorySetpoint_ = nullptr;
+};
+
+}  // namespace cl_px4_mr

--- a/smacc2_client_library/cl_px4_mr/include/cl_px4_mr/client_behaviors/cb_follow_waypoints.hpp
+++ b/smacc2_client_library/cl_px4_mr/include/cl_px4_mr/client_behaviors/cb_follow_waypoints.hpp
@@ -16,8 +16,8 @@
 
 #include <array>
 #include <cmath>
-#include <vector>
 #include <smacc2/smacc.hpp>
+#include <vector>
 
 namespace cl_px4_mr
 {

--- a/smacc2_client_library/cl_px4_mr/include/cl_px4_mr/client_behaviors/cb_follow_waypoints.hpp
+++ b/smacc2_client_library/cl_px4_mr/include/cl_px4_mr/client_behaviors/cb_follow_waypoints.hpp
@@ -1,0 +1,50 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <vector>
+#include <smacc2/smacc.hpp>
+
+namespace cl_px4_mr
+{
+
+class CpTrajectorySetpoint;
+class CpGoalChecker;
+
+class CbFollowWaypoints : public smacc2::SmaccAsyncClientBehavior
+{
+public:
+  CbFollowWaypoints(
+    std::vector<std::array<float, 4>> waypoints, float xyTol = 0.5f, float zTol = 0.3f);
+
+  void onEntry() override;
+  void onExit() override;
+
+private:
+  void onGoalReachedCallback();
+  void commandCurrentWaypoint();
+
+  std::vector<std::array<float, 4>> waypoints_;
+  float xyTol_;
+  float zTol_;
+  size_t currentIndex_ = 0;
+
+  CpTrajectorySetpoint * trajectorySetpoint_ = nullptr;
+  CpGoalChecker * goalChecker_ = nullptr;
+};
+
+}  // namespace cl_px4_mr

--- a/smacc2_client_library/cl_px4_mr/include/cl_px4_mr/client_behaviors/cb_hold_position.hpp
+++ b/smacc2_client_library/cl_px4_mr/include/cl_px4_mr/client_behaviors/cb_hold_position.hpp
@@ -1,0 +1,41 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <chrono>
+#include <smacc2/smacc.hpp>
+
+namespace cl_px4_mr
+{
+
+class CpTrajectorySetpoint;
+
+class CbHoldPosition : public smacc2::SmaccAsyncClientBehavior, public smacc2::ISmaccUpdatable
+{
+public:
+  explicit CbHoldPosition(float durationSeconds = 5.0f);
+
+  void onEntry() override;
+  void onExit() override;
+  void update() override;
+
+private:
+  float durationSeconds_;
+  std::chrono::steady_clock::time_point startTime_;
+
+  CpTrajectorySetpoint * trajectorySetpoint_ = nullptr;
+};
+
+}  // namespace cl_px4_mr

--- a/smacc2_client_library/cl_px4_mr/include/cl_px4_mr/client_behaviors/cb_return_to_home.hpp
+++ b/smacc2_client_library/cl_px4_mr/include/cl_px4_mr/client_behaviors/cb_return_to_home.hpp
@@ -1,0 +1,45 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace cl_px4_mr
+{
+
+class CpTrajectorySetpoint;
+class CpGoalChecker;
+
+class CbReturnToHome : public smacc2::SmaccAsyncClientBehavior
+{
+public:
+  CbReturnToHome(float homeX, float homeY, float homeZ, float homeYaw);
+
+  void onEntry() override;
+  void onExit() override;
+
+private:
+  void onGoalReachedCallback();
+
+  float homeX_;
+  float homeY_;
+  float homeZ_;
+  float homeYaw_;
+
+  CpTrajectorySetpoint * trajectorySetpoint_ = nullptr;
+  CpGoalChecker * goalChecker_ = nullptr;
+};
+
+}  // namespace cl_px4_mr

--- a/smacc2_client_library/cl_px4_mr/include/cl_px4_mr/client_behaviors/cb_spiral_pattern.hpp
+++ b/smacc2_client_library/cl_px4_mr/include/cl_px4_mr/client_behaviors/cb_spiral_pattern.hpp
@@ -1,0 +1,53 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <chrono>
+#include <cmath>
+#include <smacc2/smacc.hpp>
+
+namespace cl_px4_mr
+{
+
+class CpTrajectorySetpoint;
+class CpVehicleLocalPosition;
+
+class CbSpiralPattern : public smacc2::SmaccAsyncClientBehavior, public smacc2::ISmaccUpdatable
+{
+public:
+  CbSpiralPattern(
+    float centerX, float centerY, float altitude, float maxRadius = 20.0f, float spacing = 3.0f,
+    float speed = 2.0f);
+
+  void onEntry() override;
+  void onExit() override;
+  void update() override;
+
+private:
+  float centerX_;
+  float centerY_;
+  float altitude_;
+  float maxRadius_;
+  float spacing_;
+  float speed_;
+
+  float theta_ = 0.0f;
+  std::chrono::steady_clock::time_point lastUpdateTime_;
+
+  CpTrajectorySetpoint * trajectorySetpoint_ = nullptr;
+  CpVehicleLocalPosition * localPosition_ = nullptr;
+};
+
+}  // namespace cl_px4_mr

--- a/smacc2_client_library/cl_px4_mr/include/cl_px4_mr/client_behaviors/cb_yaw_rotate.hpp
+++ b/smacc2_client_library/cl_px4_mr/include/cl_px4_mr/client_behaviors/cb_yaw_rotate.hpp
@@ -1,0 +1,44 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cmath>
+#include <smacc2/smacc.hpp>
+
+namespace cl_px4_mr
+{
+
+class CpTrajectorySetpoint;
+class CpVehicleLocalPosition;
+
+class CbYawRotate : public smacc2::SmaccAsyncClientBehavior, public smacc2::ISmaccUpdatable
+{
+public:
+  CbYawRotate(float targetYawRad, bool relative = false);
+
+  void onEntry() override;
+  void onExit() override;
+  void update() override;
+
+private:
+  float targetYawRad_;
+  bool relative_;
+  float absoluteTargetYaw_ = 0.0f;
+
+  CpTrajectorySetpoint * trajectorySetpoint_ = nullptr;
+  CpVehicleLocalPosition * localPosition_ = nullptr;
+};
+
+}  // namespace cl_px4_mr

--- a/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_change_altitude.cpp
+++ b/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_change_altitude.cpp
@@ -1,0 +1,55 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cl_px4_mr/client_behaviors/cb_change_altitude.hpp>
+#include <cl_px4_mr/components/cp_goal_checker.hpp>
+#include <cl_px4_mr/components/cp_trajectory_setpoint.hpp>
+#include <cl_px4_mr/components/cp_vehicle_local_position.hpp>
+
+namespace cl_px4_mr
+{
+
+CbChangeAltitude::CbChangeAltitude(float targetAltitude) : targetAltitude_(targetAltitude) {}
+
+void CbChangeAltitude::onEntry()
+{
+  this->requiresComponent(trajectorySetpoint_);
+  this->requiresComponent(goalChecker_);
+  this->requiresComponent(localPosition_);
+
+  this->getStateMachine()->createSignalConnection(
+    goalChecker_->onGoalReached_, &CbChangeAltitude::onGoalReachedCallback, this);
+
+  float currentX = localPosition_->getX();
+  float currentY = localPosition_->getY();
+  float currentHeading = localPosition_->getHeading();
+  float targetZ = -targetAltitude_;  // NED: up is negative Z
+
+  RCLCPP_INFO(
+    getLogger(), "CbChangeAltitude: changing altitude to %.2f m (NED z=%.2f)", targetAltitude_,
+    targetZ);
+
+  trajectorySetpoint_->setPositionNED(currentX, currentY, targetZ, currentHeading);
+  goalChecker_->setGoal(currentX, currentY, targetZ, 0.5f, 0.3f);
+}
+
+void CbChangeAltitude::onExit() { goalChecker_->clearGoal(); }
+
+void CbChangeAltitude::onGoalReachedCallback()
+{
+  RCLCPP_INFO(getLogger(), "CbChangeAltitude: target altitude reached - posting success");
+  this->postSuccessEvent();
+}
+
+}  // namespace cl_px4_mr

--- a/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_figure_eight.cpp
+++ b/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_figure_eight.cpp
@@ -1,0 +1,94 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cl_px4_mr/client_behaviors/cb_figure_eight.hpp>
+#include <cl_px4_mr/components/cp_trajectory_setpoint.hpp>
+
+namespace cl_px4_mr
+{
+
+CbFigureEight::CbFigureEight(
+  float centerX, float centerY, float altitude, float size, float speed, int numLoops)
+: centerX_(centerX),
+  centerY_(centerY),
+  altitude_(altitude),
+  size_(size),
+  speed_(speed),
+  numLoops_(numLoops)
+{
+}
+
+void CbFigureEight::onEntry()
+{
+  this->requiresComponent(trajectorySetpoint_);
+
+  t_ = 0.0f;
+  lastUpdateTime_ = std::chrono::steady_clock::now();
+
+  // Command initial position (t=0: x=size, y=0 relative to center)
+  float x = centerX_ + size_;
+  float y = centerY_;
+  float z = -altitude_;  // NED
+
+  RCLCPP_INFO(
+    getLogger(),
+    "CbFigureEight: starting figure-8 center=[%.2f, %.2f] alt=%.2f size=%.2f loops=%d",
+    centerX_, centerY_, altitude_, size_, numLoops_);
+
+  trajectorySetpoint_->setPositionNED(x, y, z, 0.0f);
+}
+
+void CbFigureEight::onExit() {}
+
+void CbFigureEight::update()
+{
+  auto now = std::chrono::steady_clock::now();
+  double dt = std::chrono::duration<double>(now - lastUpdateTime_).count();
+  lastUpdateTime_ = now;
+
+  t_ += speed_ * dt;
+
+  // Lemniscate of Bernoulli parametric equations
+  float sinT = std::sin(t_);
+  float cosT = std::cos(t_);
+  float denom = 1.0f + sinT * sinT;
+
+  float localX = size_ * cosT / denom;
+  float localY = size_ * sinT * cosT / denom;
+
+  float x = centerX_ + localX;
+  float y = centerY_ + localY;
+  float z = -altitude_;  // NED
+
+  // Compute derivatives for yaw (face direction of travel)
+  float sinT2 = sinT * sinT;
+  float cosT2 = cosT * cosT;
+  float denom2 = denom * denom;
+  float dxdt = size_ * (-sinT * (1.0f + sinT2) - cosT * 2.0f * sinT * cosT) / denom2;
+  float dydt = size_ * ((cosT2 - sinT2) * (1.0f + sinT2) - sinT * cosT * 2.0f * sinT * cosT) / denom2;
+  float yaw = std::atan2(dydt, dxdt);
+
+  trajectorySetpoint_->setPositionNED(x, y, z, yaw);
+
+  // Check completion
+  float requiredT = numLoops_ * 2.0f * M_PI;
+  if (t_ >= requiredT)
+  {
+    RCLCPP_INFO(
+      getLogger(), "CbFigureEight: %d loops completed - posting success", numLoops_);
+    this->postSuccessEvent();
+  }
+}
+
+}  // namespace cl_px4_mr

--- a/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_figure_eight.cpp
+++ b/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_figure_eight.cpp
@@ -42,8 +42,7 @@ void CbFigureEight::onEntry()
   float z = -altitude_;  // NED
 
   RCLCPP_INFO(
-    getLogger(),
-    "CbFigureEight: starting figure-8 center=[%.2f, %.2f] alt=%.2f size=%.2f loops=%d",
+    getLogger(), "CbFigureEight: starting figure-8 center=[%.2f, %.2f] alt=%.2f size=%.2f loops=%d",
     centerX_, centerY_, altitude_, size_, numLoops_);
 
   trajectorySetpoint_->setPositionNED(x, y, z, 0.0f);
@@ -76,7 +75,8 @@ void CbFigureEight::update()
   float cosT2 = cosT * cosT;
   float denom2 = denom * denom;
   float dxdt = size_ * (-sinT * (1.0f + sinT2) - cosT * 2.0f * sinT * cosT) / denom2;
-  float dydt = size_ * ((cosT2 - sinT2) * (1.0f + sinT2) - sinT * cosT * 2.0f * sinT * cosT) / denom2;
+  float dydt =
+    size_ * ((cosT2 - sinT2) * (1.0f + sinT2) - sinT * cosT * 2.0f * sinT * cosT) / denom2;
   float yaw = std::atan2(dydt, dxdt);
 
   trajectorySetpoint_->setPositionNED(x, y, z, yaw);
@@ -85,8 +85,7 @@ void CbFigureEight::update()
   float requiredT = numLoops_ * 2.0f * M_PI;
   if (t_ >= requiredT)
   {
-    RCLCPP_INFO(
-      getLogger(), "CbFigureEight: %d loops completed - posting success", numLoops_);
+    RCLCPP_INFO(getLogger(), "CbFigureEight: %d loops completed - posting success", numLoops_);
     this->postSuccessEvent();
   }
 }

--- a/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_follow_waypoints.cpp
+++ b/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_follow_waypoints.cpp
@@ -1,0 +1,85 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cl_px4_mr/client_behaviors/cb_follow_waypoints.hpp>
+#include <cl_px4_mr/components/cp_goal_checker.hpp>
+#include <cl_px4_mr/components/cp_trajectory_setpoint.hpp>
+
+namespace cl_px4_mr
+{
+
+CbFollowWaypoints::CbFollowWaypoints(
+  std::vector<std::array<float, 4>> waypoints, float xyTol, float zTol)
+: waypoints_(std::move(waypoints)), xyTol_(xyTol), zTol_(zTol)
+{
+}
+
+void CbFollowWaypoints::onEntry()
+{
+  this->requiresComponent(trajectorySetpoint_);
+  this->requiresComponent(goalChecker_);
+
+  this->getStateMachine()->createSignalConnection(
+    goalChecker_->onGoalReached_, &CbFollowWaypoints::onGoalReachedCallback, this);
+
+  if (waypoints_.empty())
+  {
+    RCLCPP_WARN(getLogger(), "CbFollowWaypoints: no waypoints provided - posting success");
+    this->postSuccessEvent();
+    return;
+  }
+
+  RCLCPP_INFO(
+    getLogger(), "CbFollowWaypoints: following %zu waypoints", waypoints_.size());
+
+  currentIndex_ = 0;
+  commandCurrentWaypoint();
+}
+
+void CbFollowWaypoints::onExit() { goalChecker_->clearGoal(); }
+
+void CbFollowWaypoints::commandCurrentWaypoint()
+{
+  const auto & wp = waypoints_[currentIndex_];
+  float x = wp[0];
+  float y = wp[1];
+  float z = wp[2];
+  float yaw = wp[3];
+
+  RCLCPP_INFO(
+    getLogger(), "CbFollowWaypoints: commanding waypoint %zu/%zu [%.2f, %.2f, %.2f] yaw=%.2f",
+    currentIndex_ + 1, waypoints_.size(), x, y, z, yaw);
+
+  trajectorySetpoint_->setPositionNED(x, y, z, yaw);
+  goalChecker_->setGoal(x, y, z, xyTol_, zTol_);
+}
+
+void CbFollowWaypoints::onGoalReachedCallback()
+{
+  currentIndex_++;
+
+  if (currentIndex_ >= waypoints_.size())
+  {
+    RCLCPP_INFO(
+      getLogger(), "CbFollowWaypoints: all %zu waypoints reached - posting success",
+      waypoints_.size());
+    this->postSuccessEvent();
+  }
+  else
+  {
+    commandCurrentWaypoint();
+  }
+}
+
+}  // namespace cl_px4_mr

--- a/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_follow_waypoints.cpp
+++ b/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_follow_waypoints.cpp
@@ -40,8 +40,7 @@ void CbFollowWaypoints::onEntry()
     return;
   }
 
-  RCLCPP_INFO(
-    getLogger(), "CbFollowWaypoints: following %zu waypoints", waypoints_.size());
+  RCLCPP_INFO(getLogger(), "CbFollowWaypoints: following %zu waypoints", waypoints_.size());
 
   currentIndex_ = 0;
   commandCurrentWaypoint();

--- a/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_hold_position.cpp
+++ b/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_hold_position.cpp
@@ -1,0 +1,47 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cl_px4_mr/client_behaviors/cb_hold_position.hpp>
+#include <cl_px4_mr/components/cp_trajectory_setpoint.hpp>
+
+namespace cl_px4_mr
+{
+
+CbHoldPosition::CbHoldPosition(float durationSeconds) : durationSeconds_(durationSeconds) {}
+
+void CbHoldPosition::onEntry()
+{
+  this->requiresComponent(trajectorySetpoint_);
+
+  RCLCPP_INFO(getLogger(), "CbHoldPosition: holding position for %.1f seconds", durationSeconds_);
+
+  trajectorySetpoint_->hold();
+  startTime_ = std::chrono::steady_clock::now();
+}
+
+void CbHoldPosition::onExit() {}
+
+void CbHoldPosition::update()
+{
+  auto now = std::chrono::steady_clock::now();
+  double elapsed = std::chrono::duration<double>(now - startTime_).count();
+
+  if (elapsed >= durationSeconds_)
+  {
+    RCLCPP_INFO(getLogger(), "CbHoldPosition: duration reached (%.1f s) - posting success", elapsed);
+    this->postSuccessEvent();
+  }
+}
+
+}  // namespace cl_px4_mr

--- a/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_hold_position.cpp
+++ b/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_hold_position.cpp
@@ -39,7 +39,8 @@ void CbHoldPosition::update()
 
   if (elapsed >= durationSeconds_)
   {
-    RCLCPP_INFO(getLogger(), "CbHoldPosition: duration reached (%.1f s) - posting success", elapsed);
+    RCLCPP_INFO(
+      getLogger(), "CbHoldPosition: duration reached (%.1f s) - posting success", elapsed);
     this->postSuccessEvent();
   }
 }

--- a/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_return_to_home.cpp
+++ b/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_return_to_home.cpp
@@ -1,0 +1,51 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cl_px4_mr/client_behaviors/cb_return_to_home.hpp>
+#include <cl_px4_mr/components/cp_goal_checker.hpp>
+#include <cl_px4_mr/components/cp_trajectory_setpoint.hpp>
+
+namespace cl_px4_mr
+{
+
+CbReturnToHome::CbReturnToHome(float homeX, float homeY, float homeZ, float homeYaw)
+: homeX_(homeX), homeY_(homeY), homeZ_(homeZ), homeYaw_(homeYaw)
+{
+}
+
+void CbReturnToHome::onEntry()
+{
+  this->requiresComponent(trajectorySetpoint_);
+  this->requiresComponent(goalChecker_);
+
+  this->getStateMachine()->createSignalConnection(
+    goalChecker_->onGoalReached_, &CbReturnToHome::onGoalReachedCallback, this);
+
+  RCLCPP_INFO(
+    getLogger(), "CbReturnToHome: returning to home [%.2f, %.2f, %.2f] yaw=%.2f", homeX_, homeY_,
+    homeZ_, homeYaw_);
+
+  trajectorySetpoint_->setPositionNED(homeX_, homeY_, homeZ_, homeYaw_);
+  goalChecker_->setGoal(homeX_, homeY_, homeZ_);
+}
+
+void CbReturnToHome::onExit() { goalChecker_->clearGoal(); }
+
+void CbReturnToHome::onGoalReachedCallback()
+{
+  RCLCPP_INFO(getLogger(), "CbReturnToHome: home position reached - posting success");
+  this->postSuccessEvent();
+}
+
+}  // namespace cl_px4_mr

--- a/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_spiral_pattern.cpp
+++ b/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_spiral_pattern.cpp
@@ -1,0 +1,101 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cl_px4_mr/client_behaviors/cb_spiral_pattern.hpp>
+#include <cl_px4_mr/components/cp_trajectory_setpoint.hpp>
+#include <cl_px4_mr/components/cp_vehicle_local_position.hpp>
+
+namespace cl_px4_mr
+{
+
+CbSpiralPattern::CbSpiralPattern(
+  float centerX, float centerY, float altitude, float maxRadius, float spacing, float speed)
+: centerX_(centerX),
+  centerY_(centerY),
+  altitude_(altitude),
+  maxRadius_(maxRadius),
+  spacing_(spacing),
+  speed_(speed)
+{
+}
+
+void CbSpiralPattern::onEntry()
+{
+  this->requiresComponent(trajectorySetpoint_);
+  this->requiresComponent(localPosition_);
+
+  theta_ = 0.0f;
+  lastUpdateTime_ = std::chrono::steady_clock::now();
+
+  // Initial position is the spiral center
+  float z = -altitude_;  // NED: up is negative
+
+  RCLCPP_INFO(
+    getLogger(),
+    "CbSpiralPattern: starting spiral center=[%.2f, %.2f] alt=%.2f maxR=%.2f spacing=%.2f "
+    "speed=%.2f",
+    centerX_, centerY_, altitude_, maxRadius_, spacing_, speed_);
+
+  trajectorySetpoint_->setPositionNED(centerX_, centerY_, z, 0.0f);
+}
+
+void CbSpiralPattern::onExit() {}
+
+void CbSpiralPattern::update()
+{
+  auto now = std::chrono::steady_clock::now();
+  double dt = std::chrono::duration<double>(now - lastUpdateTime_).count();
+  lastUpdateTime_ = now;
+
+  // Archimedean spiral: r(theta) = a * theta
+  // where a = spacing / (2*PI) so each revolution adds 'spacing' meters of radius
+  float a = spacing_ / (2.0f * M_PI);
+
+  // Current radius
+  float r = a * theta_;
+
+  // Adaptive angular velocity to maintain constant linear speed
+  // Arc-length speed: ds/dt = sqrt(r^2 + a^2) * dtheta/dt
+  // Solving for dtheta/dt: omega = speed / sqrt(r^2 + a^2)
+  float omega = speed_ / std::sqrt(r * r + a * a);
+
+  // Advance angle
+  theta_ += omega * dt;
+
+  // Compute new position
+  float r_new = a * theta_;
+  float x = centerX_ + r_new * std::cos(theta_);
+  float y = centerY_ + r_new * std::sin(theta_);
+  float z = -altitude_;  // NED
+
+  // Yaw: face direction of travel (derivatives of Archimedean spiral)
+  // dx/dtheta = a*cos(theta) - r*sin(theta)
+  // dy/dtheta = a*sin(theta) + r*cos(theta)
+  float dxdt = a * std::cos(theta_) - r_new * std::sin(theta_);
+  float dydt = a * std::sin(theta_) + r_new * std::cos(theta_);
+  float yaw = std::atan2(dydt, dxdt);
+
+  trajectorySetpoint_->setPositionNED(x, y, z, yaw);
+
+  // Check completion
+  if (r_new >= maxRadius_)
+  {
+    RCLCPP_INFO(
+      getLogger(), "CbSpiralPattern: max radius %.2f reached (r=%.2f) - posting success",
+      maxRadius_, r_new);
+    this->postSuccessEvent();
+  }
+}
+
+}  // namespace cl_px4_mr

--- a/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_yaw_rotate.cpp
+++ b/smacc2_client_library/cl_px4_mr/src/cl_px4_mr/client_behaviors/cb_yaw_rotate.cpp
@@ -1,0 +1,76 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cl_px4_mr/client_behaviors/cb_yaw_rotate.hpp>
+#include <cl_px4_mr/components/cp_trajectory_setpoint.hpp>
+#include <cl_px4_mr/components/cp_vehicle_local_position.hpp>
+
+namespace cl_px4_mr
+{
+
+CbYawRotate::CbYawRotate(float targetYawRad, bool relative)
+: targetYawRad_(targetYawRad), relative_(relative)
+{
+}
+
+void CbYawRotate::onEntry()
+{
+  this->requiresComponent(trajectorySetpoint_);
+  this->requiresComponent(localPosition_);
+
+  float currentYaw = localPosition_->getHeading();
+
+  if (relative_)
+  {
+    absoluteTargetYaw_ = currentYaw + targetYawRad_;
+  }
+  else
+  {
+    absoluteTargetYaw_ = targetYawRad_;
+  }
+
+  // Normalize to [-PI, PI]
+  absoluteTargetYaw_ = std::atan2(std::sin(absoluteTargetYaw_), std::cos(absoluteTargetYaw_));
+
+  float curX = localPosition_->getX();
+  float curY = localPosition_->getY();
+  float curZ = localPosition_->getZ();
+
+  RCLCPP_INFO(
+    getLogger(), "CbYawRotate: rotating from %.2f to %.2f rad (relative=%d)", currentYaw,
+    absoluteTargetYaw_, relative_);
+
+  trajectorySetpoint_->setPositionNED(curX, curY, curZ, absoluteTargetYaw_);
+}
+
+void CbYawRotate::onExit() {}
+
+void CbYawRotate::update()
+{
+  float currentYaw = localPosition_->getHeading();
+
+  // Compute shortest angular distance
+  float diff = absoluteTargetYaw_ - currentYaw;
+  diff = std::atan2(std::sin(diff), std::cos(diff));
+
+  if (std::abs(diff) < 0.1f)
+  {
+    RCLCPP_INFO(
+      getLogger(), "CbYawRotate: target yaw reached (error=%.3f rad) - posting success",
+      std::abs(diff));
+    this->postSuccessEvent();
+  }
+}
+
+}  // namespace cl_px4_mr

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/CMakeLists.txt
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.5)
+project(sm_cl_px4_mr_test_2)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(smacc2 REQUIRED)
+find_package(cl_px4_mr REQUIRED)
+find_package(cl_ros2_timer REQUIRED)
+find_package(px4_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(Boost COMPONENTS thread REQUIRED)
+
+include_directories(include
+  ${smacc2_INCLUDE_DIRS}
+  ${cl_px4_mr_INCLUDE_DIRS}
+  ${cl_ros2_timer_INCLUDE_DIRS}
+)
+
+add_executable(${PROJECT_NAME}_node
+  src/sm_cl_px4_mr_test_2/sm_cl_px4_mr_test_2_node.cpp)
+
+target_link_libraries(${PROJECT_NAME}_node
+  ${smacc2_LIBRARIES}
+  ${cl_px4_mr_LIBRARIES}
+  ${cl_ros2_timer_LIBRARIES}
+  ${Boost_LIBRARIES}
+)
+
+ament_target_dependencies(${PROJECT_NAME}_node
+  smacc2
+  cl_px4_mr
+  cl_ros2_timer
+  px4_msgs
+  rclcpp
+)
+
+install(DIRECTORY include/
+  DESTINATION include)
+
+install(DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME})
+
+install(TARGETS ${PROJECT_NAME}_node
+  DESTINATION lib/${PROJECT_NAME})
+
+ament_package()

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/orthogonals/or_px4.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/orthogonals/or_px4.hpp
@@ -1,0 +1,32 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+#include <cl_px4_mr/cl_px4_mr.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+class OrPx4 : public smacc2::Orthogonal<OrPx4>
+{
+public:
+  void onInitialize() override
+  {
+    auto client = this->createClient<cl_px4_mr::ClPx4Mr>();
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/orthogonals/or_timer.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/orthogonals/or_timer.hpp
@@ -1,0 +1,35 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+#include <cl_ros2_timer/cl_ros2_timer.hpp>
+#include <chrono>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace std::chrono_literals;
+
+class OrTimer : public smacc2::Orthogonal<OrTimer>
+{
+public:
+  void onInitialize() override
+  {
+    auto client = this->createClient<cl_ros2_timer::ClRos2Timer>(rclcpp::Duration(1s));
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/sm_cl_px4_mr_test_2.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/sm_cl_px4_mr_test_2.hpp
@@ -1,0 +1,116 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+// CLIENTS
+#include <cl_px4_mr/cl_px4_mr.hpp>
+#include <cl_ros2_timer/cl_ros2_timer.hpp>
+
+// CLIENT BEHAVIORS
+#include <cl_px4_mr/client_behaviors/cb_arm_px4.hpp>
+#include <cl_px4_mr/client_behaviors/cb_change_altitude.hpp>
+#include <cl_px4_mr/client_behaviors/cb_disarm_px4.hpp>
+#include <cl_px4_mr/client_behaviors/cb_figure_eight.hpp>
+#include <cl_px4_mr/client_behaviors/cb_follow_waypoints.hpp>
+#include <cl_px4_mr/client_behaviors/cb_go_to_location.hpp>
+#include <cl_px4_mr/client_behaviors/cb_hold_position.hpp>
+#include <cl_px4_mr/client_behaviors/cb_land.hpp>
+#include <cl_px4_mr/client_behaviors/cb_orbit_location.hpp>
+#include <cl_px4_mr/client_behaviors/cb_return_to_home.hpp>
+#include <cl_px4_mr/client_behaviors/cb_spiral_pattern.hpp>
+#include <cl_px4_mr/client_behaviors/cb_takeoff.hpp>
+#include <cl_px4_mr/client_behaviors/cb_yaw_rotate.hpp>
+#include <cl_ros2_timer/client_behaviors/cb_timer_countdown_once.hpp>
+
+// ORTHOGONALS
+#include <sm_cl_px4_mr_test_2/orthogonals/or_px4.hpp>
+#include <sm_cl_px4_mr_test_2/orthogonals/or_timer.hpp>
+
+using namespace boost;
+using namespace smacc2;
+
+namespace sm_cl_px4_mr_test_2
+{
+
+// MODE STATES (forward declarations)
+class MsDisarmedOnGround;
+class MsArmedOnGround;
+class MsTakeoff;
+class MsInFlight;
+class MsLanding;
+class MsLanded;
+
+// STATES (forward declarations)
+class StWaitForReady;
+class StArmPx4;
+class StTakeoff;
+class StHoldPosition;
+class StYawRotate;
+class StHoldPosition2;
+class StChangeAltitude;
+class StHoldPosition3;
+class StSpiralPattern;
+class StHoldPosition4;
+class StFollowWaypoints;
+class StHoldPosition5;
+class StFigureEight;
+class StHoldPosition6;
+class StReturnToHome;
+class StLand;
+class StLanded;
+
+// STATE MACHINE
+struct SmClPx4MrTest2
+: public smacc2::SmaccStateMachineBase<SmClPx4MrTest2, MsDisarmedOnGround>
+{
+  using SmaccStateMachineBase::SmaccStateMachineBase;
+
+  void onInitialize() override
+  {
+    this->createOrthogonal<OrPx4>();
+    this->createOrthogonal<OrTimer>();
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2
+
+// MODE STATE INCLUDES (must come after SM definition, before regular states)
+#include <sm_cl_px4_mr_test_2/states/ms_disarmed_on_ground.hpp>
+#include <sm_cl_px4_mr_test_2/states/ms_armed_on_ground.hpp>
+#include <sm_cl_px4_mr_test_2/states/ms_takeoff.hpp>
+#include <sm_cl_px4_mr_test_2/states/ms_in_flight.hpp>
+#include <sm_cl_px4_mr_test_2/states/ms_landing.hpp>
+#include <sm_cl_px4_mr_test_2/states/ms_landed.hpp>
+
+// REGULAR STATE INCLUDES (must come after mode state definitions)
+#include <sm_cl_px4_mr_test_2/states/st_wait_for_ready.hpp>
+#include <sm_cl_px4_mr_test_2/states/st_arm_px4.hpp>
+#include <sm_cl_px4_mr_test_2/states/st_takeoff.hpp>
+#include <sm_cl_px4_mr_test_2/states/st_hold_position.hpp>
+#include <sm_cl_px4_mr_test_2/states/st_yaw_rotate.hpp>
+#include <sm_cl_px4_mr_test_2/states/st_hold_position_2.hpp>
+#include <sm_cl_px4_mr_test_2/states/st_change_altitude.hpp>
+#include <sm_cl_px4_mr_test_2/states/st_hold_position_3.hpp>
+#include <sm_cl_px4_mr_test_2/states/st_spiral_pattern.hpp>
+#include <sm_cl_px4_mr_test_2/states/st_hold_position_4.hpp>
+#include <sm_cl_px4_mr_test_2/states/st_follow_waypoints.hpp>
+#include <sm_cl_px4_mr_test_2/states/st_hold_position_5.hpp>
+#include <sm_cl_px4_mr_test_2/states/st_figure_eight.hpp>
+#include <sm_cl_px4_mr_test_2/states/st_hold_position_6.hpp>
+#include <sm_cl_px4_mr_test_2/states/st_return_to_home.hpp>
+#include <sm_cl_px4_mr_test_2/states/st_land.hpp>
+#include <sm_cl_px4_mr_test_2/states/st_landed.hpp>

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/ms_armed_on_ground.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/ms_armed_on_ground.hpp
@@ -1,0 +1,45 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+// MODE STATE: Vehicle is being armed
+struct MsArmedOnGround
+: smacc2::SmaccState<MsArmedOnGround, SmClPx4MrTest2, StArmPx4>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+  > reactions;
+
+  static void staticConfigure() {}
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "--- MsArmedOnGround ---");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "--- Exiting MsArmedOnGround ---");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/ms_disarmed_on_ground.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/ms_disarmed_on_ground.hpp
@@ -1,0 +1,45 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+// MODE STATE: Vehicle is disarmed on the ground, waiting for readiness
+struct MsDisarmedOnGround
+: smacc2::SmaccState<MsDisarmedOnGround, SmClPx4MrTest2, StWaitForReady>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+  > reactions;
+
+  static void staticConfigure() {}
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "--- MsDisarmedOnGround ---");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "--- Exiting MsDisarmedOnGround ---");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/ms_in_flight.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/ms_in_flight.hpp
@@ -1,0 +1,45 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+// MODE STATE: Vehicle is airborne and executing mission
+struct MsInFlight
+: smacc2::SmaccState<MsInFlight, SmClPx4MrTest2, StHoldPosition>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+  > reactions;
+
+  static void staticConfigure() {}
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "--- MsInFlight ---");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "--- Exiting MsInFlight ---");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/ms_landed.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/ms_landed.hpp
@@ -1,0 +1,45 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+// MODE STATE: Vehicle has landed, mission complete
+struct MsLanded
+: smacc2::SmaccState<MsLanded, SmClPx4MrTest2, StLanded>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+  > reactions;
+
+  static void staticConfigure() {}
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "--- MsLanded ---");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "--- Exiting MsLanded ---");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/ms_landing.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/ms_landing.hpp
@@ -1,0 +1,45 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+// MODE STATE: Vehicle is landing
+struct MsLanding
+: smacc2::SmaccState<MsLanding, SmClPx4MrTest2, StLand>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+  > reactions;
+
+  static void staticConfigure() {}
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "--- MsLanding ---");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "--- Exiting MsLanding ---");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/ms_takeoff.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/ms_takeoff.hpp
@@ -1,0 +1,45 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+// MODE STATE: Vehicle is taking off
+struct MsTakeoff
+: smacc2::SmaccState<MsTakeoff, SmClPx4MrTest2, StTakeoff>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+  > reactions;
+
+  static void staticConfigure() {}
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "--- MsTakeoff ---");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "--- Exiting MsTakeoff ---");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_arm_px4.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_arm_px4.hpp
@@ -1,0 +1,52 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace cl_px4_mr;
+using namespace smacc2::default_transition_tags;
+
+// STATE: Arm the vehicle
+struct StArmPx4 : smacc2::SmaccState<StArmPx4, MsArmedOnGround>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+    Transition<EvCbSuccess<CbArmPX4, OrPx4>, MsTakeoff, SUCCESS>
+  > reactions;
+
+  static void staticConfigure()
+  {
+    configure_orthogonal<OrPx4, CbArmPX4>();
+  }
+
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "StArmPx4: arming vehicle...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "StArmPx4: vehicle armed");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_change_altitude.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_change_altitude.hpp
@@ -1,0 +1,53 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace cl_px4_mr;
+using namespace smacc2::default_transition_tags;
+
+// STATE: Climb to 20m altitude
+struct StChangeAltitude : smacc2::SmaccState<StChangeAltitude, MsInFlight>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+    Transition<EvCbSuccess<CbChangeAltitude, OrPx4>, StHoldPosition3, SUCCESS>
+  > reactions;
+
+  static void staticConfigure()
+  {
+    // Ascend to 20 meters (positive = meters above ground)
+    configure_orthogonal<OrPx4, CbChangeAltitude>(20.0f);
+  }
+
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "StChangeAltitude: climbing to 20m...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "StChangeAltitude: altitude reached");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_figure_eight.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_figure_eight.hpp
@@ -1,0 +1,53 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace cl_px4_mr;
+using namespace smacc2::default_transition_tags;
+
+// STATE: Fly a figure-8 (lemniscate) pattern
+struct StFigureEight : smacc2::SmaccState<StFigureEight, MsInFlight>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+    Transition<EvCbSuccess<CbFigureEight, OrPx4>, StHoldPosition6, SUCCESS>
+  > reactions;
+
+  static void staticConfigure()
+  {
+    // Figure-8 centered at (5, 5) NED, 20m altitude, 5m size, 0.5 speed, 3 loops
+    configure_orthogonal<OrPx4, CbFigureEight>(5.0f, 5.0f, 20.0f, 5.0f, 0.5f, 3);
+  }
+
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "StFigureEight: starting figure-8 pattern...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "StFigureEight: figure-8 complete");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_follow_waypoints.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_follow_waypoints.hpp
@@ -1,0 +1,60 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cmath>
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace cl_px4_mr;
+using namespace smacc2::default_transition_tags;
+
+// STATE: Follow a triangle of 3 waypoints at 20m altitude
+struct StFollowWaypoints : smacc2::SmaccState<StFollowWaypoints, MsInFlight>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+    Transition<EvCbSuccess<CbFollowWaypoints, OrPx4>, StHoldPosition5, SUCCESS>
+  > reactions;
+
+  static void staticConfigure()
+  {
+    // Waypoint pattern at 20m altitude (NED: z = -20), going left (negative Y)
+    // Each waypoint: {x, y, z, yaw} — yaw=NAN means maintain current heading
+    configure_orthogonal<OrPx4, CbFollowWaypoints>(
+      std::vector<std::array<float, 4>>{
+        {30.0f, 0.0f, -20.0f, NAN},     // 30m North
+        {30.0f, -30.0f, -20.0f, NAN},   // 30m North, 30m West
+        {0.0f, -30.0f, -20.0f, NAN}     // 30m West
+      });
+  }
+
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "StFollowWaypoints: following 3-point triangle...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "StFollowWaypoints: all waypoints reached");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_hold_position.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_hold_position.hpp
@@ -1,0 +1,53 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace cl_px4_mr;
+using namespace smacc2::default_transition_tags;
+
+// STATE: Hold position for 3 seconds to stabilize after takeoff
+struct StHoldPosition : smacc2::SmaccState<StHoldPosition, MsInFlight>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+    Transition<EvCbSuccess<CbHoldPosition, OrPx4>, StYawRotate, SUCCESS>
+  > reactions;
+
+  static void staticConfigure()
+  {
+    // Hold current position for 3 seconds
+    configure_orthogonal<OrPx4, CbHoldPosition>(3.0f);
+  }
+
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "StHoldPosition: holding position for 3 seconds...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "StHoldPosition: hold complete");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_hold_position_2.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_hold_position_2.hpp
@@ -1,0 +1,52 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace cl_px4_mr;
+using namespace smacc2::default_transition_tags;
+
+// STATE: Hold position after yaw rotate, before change altitude
+struct StHoldPosition2 : smacc2::SmaccState<StHoldPosition2, MsInFlight>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+    Transition<EvCbSuccess<CbHoldPosition, OrPx4>, StChangeAltitude, SUCCESS>
+  > reactions;
+
+  static void staticConfigure()
+  {
+    configure_orthogonal<OrPx4, CbHoldPosition>(3.0f);
+  }
+
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "StHoldPosition2: stabilizing after yaw rotate...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "StHoldPosition2: hold complete");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_hold_position_3.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_hold_position_3.hpp
@@ -1,0 +1,52 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace cl_px4_mr;
+using namespace smacc2::default_transition_tags;
+
+// STATE: Hold position after change altitude, before spiral pattern
+struct StHoldPosition3 : smacc2::SmaccState<StHoldPosition3, MsInFlight>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+    Transition<EvCbSuccess<CbHoldPosition, OrPx4>, StSpiralPattern, SUCCESS>
+  > reactions;
+
+  static void staticConfigure()
+  {
+    configure_orthogonal<OrPx4, CbHoldPosition>(3.0f);
+  }
+
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "StHoldPosition3: stabilizing after altitude change...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "StHoldPosition3: hold complete");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_hold_position_4.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_hold_position_4.hpp
@@ -1,0 +1,52 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace cl_px4_mr;
+using namespace smacc2::default_transition_tags;
+
+// STATE: Hold position after spiral pattern, before follow waypoints
+struct StHoldPosition4 : smacc2::SmaccState<StHoldPosition4, MsInFlight>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+    Transition<EvCbSuccess<CbHoldPosition, OrPx4>, StFollowWaypoints, SUCCESS>
+  > reactions;
+
+  static void staticConfigure()
+  {
+    configure_orthogonal<OrPx4, CbHoldPosition>(3.0f);
+  }
+
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "StHoldPosition4: stabilizing after spiral pattern...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "StHoldPosition4: hold complete");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_hold_position_5.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_hold_position_5.hpp
@@ -1,0 +1,52 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace cl_px4_mr;
+using namespace smacc2::default_transition_tags;
+
+// STATE: Hold position after follow waypoints, before figure eight
+struct StHoldPosition5 : smacc2::SmaccState<StHoldPosition5, MsInFlight>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+    Transition<EvCbSuccess<CbHoldPosition, OrPx4>, StFigureEight, SUCCESS>
+  > reactions;
+
+  static void staticConfigure()
+  {
+    configure_orthogonal<OrPx4, CbHoldPosition>(3.0f);
+  }
+
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "StHoldPosition5: stabilizing after waypoints...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "StHoldPosition5: hold complete");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_hold_position_6.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_hold_position_6.hpp
@@ -1,0 +1,52 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace cl_px4_mr;
+using namespace smacc2::default_transition_tags;
+
+// STATE: Hold position after figure eight, before return to home
+struct StHoldPosition6 : smacc2::SmaccState<StHoldPosition6, MsInFlight>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+    Transition<EvCbSuccess<CbHoldPosition, OrPx4>, StReturnToHome, SUCCESS>
+  > reactions;
+
+  static void staticConfigure()
+  {
+    configure_orthogonal<OrPx4, CbHoldPosition>(3.0f);
+  }
+
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "StHoldPosition6: stabilizing after figure-8...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "StHoldPosition6: hold complete");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_land.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_land.hpp
@@ -1,0 +1,52 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace cl_px4_mr;
+using namespace smacc2::default_transition_tags;
+
+// STATE: Land the vehicle
+struct StLand : smacc2::SmaccState<StLand, MsLanding>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+    Transition<EvCbSuccess<CbLand, OrPx4>, MsLanded, SUCCESS>
+  > reactions;
+
+  static void staticConfigure()
+  {
+    configure_orthogonal<OrPx4, CbLand>();
+  }
+
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "StLand: landing...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "StLand: landed");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_landed.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_landed.hpp
@@ -1,0 +1,43 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace smacc2::default_transition_tags;
+
+// STATE: Mission complete - terminal state
+struct StLanded : smacc2::SmaccState<StLanded, MsLanded>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+  > reactions;
+
+  static void staticConfigure() {}
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "StLanded: MISSION COMPLETE");
+  }
+
+  void onExit() {}
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_return_to_home.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_return_to_home.hpp
@@ -1,0 +1,53 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace cl_px4_mr;
+using namespace smacc2::default_transition_tags;
+
+// STATE: Return to home position (origin at 15m altitude)
+struct StReturnToHome : smacc2::SmaccState<StReturnToHome, MsInFlight>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+    Transition<EvCbSuccess<CbReturnToHome, OrPx4>, MsLanding, SUCCESS>
+  > reactions;
+
+  static void staticConfigure()
+  {
+    // Return to origin at 15m altitude (NED: z = -15), heading North (yaw = 0)
+    configure_orthogonal<OrPx4, CbReturnToHome>(0.0f, 0.0f, -15.0f, 0.0f);
+  }
+
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "StReturnToHome: returning to home position...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "StReturnToHome: home position reached");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_spiral_pattern.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_spiral_pattern.hpp
@@ -1,0 +1,53 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace cl_px4_mr;
+using namespace smacc2::default_transition_tags;
+
+// STATE: Fly an expanding spiral pattern (search and rescue)
+struct StSpiralPattern : smacc2::SmaccState<StSpiralPattern, MsInFlight>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+    Transition<EvCbSuccess<CbSpiralPattern, OrPx4>, StHoldPosition4, SUCCESS>
+  > reactions;
+
+  static void staticConfigure()
+  {
+    // Spiral centered at origin, 20m altitude, 15m max radius, 3m spacing, 2 m/s speed
+    configure_orthogonal<OrPx4, CbSpiralPattern>(0.0f, 0.0f, 20.0f, 15.0f, 3.0f, 2.0f);
+  }
+
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "StSpiralPattern: starting search spiral...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "StSpiralPattern: spiral search complete");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_takeoff.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_takeoff.hpp
@@ -1,0 +1,53 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace cl_px4_mr;
+using namespace smacc2::default_transition_tags;
+
+// STATE: Take off to 15m altitude (high enough for barrel roll later)
+struct StTakeoff : smacc2::SmaccState<StTakeoff, MsTakeoff>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+    Transition<EvCbSuccess<CbTakeOff, OrPx4>, MsInFlight, SUCCESS>
+  > reactions;
+
+  static void staticConfigure()
+  {
+    // Take off to 15 meters altitude
+    configure_orthogonal<OrPx4, CbTakeOff>(15.0f);
+  }
+
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "StTakeoff: taking off to 15m...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "StTakeoff: takeoff complete");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_wait_for_ready.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_wait_for_ready.hpp
@@ -1,0 +1,53 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace cl_ros2_timer;
+using namespace smacc2::default_transition_tags;
+
+// STATE: Wait for PX4 topics to come up before proceeding
+struct StWaitForReady : smacc2::SmaccState<StWaitForReady, MsDisarmedOnGround>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+    Transition<EvTimer<CbTimerCountdownOnce, OrTimer>, MsArmedOnGround, SUCCESS>
+  > reactions;
+
+  static void staticConfigure()
+  {
+    // Wait 5 seconds for PX4 topics to stabilize
+    configure_orthogonal<OrTimer, CbTimerCountdownOnce>(5);
+  }
+
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "StWaitForReady: waiting for PX4 topics...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "StWaitForReady: ready, proceeding to arm");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_yaw_rotate.hpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/include/sm_cl_px4_mr_test_2/states/st_yaw_rotate.hpp
@@ -1,0 +1,54 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cmath>
+#include <smacc2/smacc.hpp>
+
+namespace sm_cl_px4_mr_test_2
+{
+
+using namespace cl_px4_mr;
+using namespace smacc2::default_transition_tags;
+
+// STATE: Rotate 90 degrees to the right (relative yaw)
+struct StYawRotate : smacc2::SmaccState<StYawRotate, MsInFlight>
+{
+  using SmaccState::SmaccState;
+
+  typedef mpl::list<
+    Transition<EvCbSuccess<CbYawRotate, OrPx4>, StHoldPosition2, SUCCESS>
+  > reactions;
+
+  static void staticConfigure()
+  {
+    // Rotate 90 degrees (PI/2 radians) relative to current heading
+    configure_orthogonal<OrPx4, CbYawRotate>(static_cast<float>(M_PI / 2.0), true);
+  }
+
+  void runtimeConfigure() {}
+
+  void onEntry()
+  {
+    RCLCPP_INFO(getLogger(), "StYawRotate: rotating 90 degrees...");
+  }
+
+  void onExit()
+  {
+    RCLCPP_INFO(getLogger(), "StYawRotate: rotation complete");
+  }
+};
+
+}  // namespace sm_cl_px4_mr_test_2

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/launch/sm_cl_px4_mr_test_2.launch.py
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/launch/sm_cl_px4_mr_test_2.launch.py
@@ -1,0 +1,29 @@
+# Copyright 2025 Robosoft Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            Node(
+                package="sm_cl_px4_mr_test_2",
+                executable="sm_cl_px4_mr_test_2_node",
+                output="screen",
+                arguments=["--ros-args", "--log-level", "INFO"],
+            )
+        ]
+    )

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/package.xml
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>sm_cl_px4_mr_test_2</name>
+  <version>0.1.0</version>
+  <description>SMACC2 test state machine for cl_px4_mr new behaviors (hold, yaw, altitude, waypoints, figure-8, barrel roll, return-to-home)</description>
+  <maintainer email="brett@robosoft.ai">Brett Aldrich</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>smacc2</depend>
+  <depend>cl_px4_mr</depend>
+  <depend>cl_ros2_timer</depend>
+  <depend>px4_msgs</depend>
+  <depend>rclcpp</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/src/sm_cl_px4_mr_test_2/sm_cl_px4_mr_test_2_node.cpp
+++ b/smacc2_sm_reference_library/sm_cl_px4_mr_test_2/src/sm_cl_px4_mr_test_2/sm_cl_px4_mr_test_2_node.cpp
@@ -1,0 +1,21 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sm_cl_px4_mr_test_2/sm_cl_px4_mr_test_2.hpp>
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  smacc2::run<sm_cl_px4_mr_test_2::SmClPx4MrTest2>();
+}


### PR DESCRIPTION
**Add 7 new flight behaviors and spiral search pattern to cl_px4_mr**

  Extends the PX4 multirotor client library with new position-mode behaviors for autonomous flight missions, including a search-and-rescue spiral pattern.

  **New client behaviors (8 files):**
  - CbHoldPosition — hold current position for a specified duration
  - CbYawRotate — rotate in place to an absolute or relative heading
  - CbChangeAltitude — ascend/descend while maintaining XY position
  - CbFollowWaypoints — visit a sequence of NED waypoints in order
  - CbFigureEight — fly a lemniscate of Bernoulli figure-8 pattern
  - CbReturnToHome — navigate to explicit home coordinates
  - CbSpiralPattern — fly an expanding Archimedean spiral with constant ground speed, configurable max radius and arm spacing for area coverage

  **New test state machine (sm_cl_px4_mr_test_2):**
  Exercises all new behaviors in a complete mission: arm, takeoff to 15m, hold position, yaw rotate 90°, climb to 20m, spiral search, follow waypoints, figure-eight (3 loops), return
  to home, and land. Includes stabilization holds between each maneuver for clean transitions.

  **Documentation updates:**
  - Updated cl_px4_mr README with behavior table, API descriptions, and test_2 reference
  - Updated how-to-px4.rst with folder structure, behavior catalog, and usage examples for all new behaviors
  - Added sm_cl_px4_mr_test_2 launch instructions to both docs

  **Other fixes:**
  - Fixed incomplete-type warning in cp_subprocess_executor.hpp (added missing smacc_state_machine.hpp include)
  - Added ros-jazzy-micro-ros-msgs to RDC Docker layer 3
