### PR TITLE
Add missing build dependencies on boost

### DIFF
--- a/smacc2_client_library/cl_nav2z/custom_planners/backward_local_planner/package.xml
+++ b/smacc2_client_library/cl_nav2z/custom_planners/backward_local_planner/package.xml
@@ -19,6 +19,7 @@
   <depend>nav_2d_utils</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>
+  <build_depend>boost</build_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/smacc2_client_library/cl_nav2z/custom_planners/forward_global_planner/package.xml
+++ b/smacc2_client_library/cl_nav2z/custom_planners/forward_global_planner/package.xml
@@ -18,6 +18,7 @@
   <depend>nav_msgs</depend>
   <depend>nav2_core</depend>
   <depend>nav2_costmap_2d</depend>
+  <build_depend>boost</build_depend>
   <build_depend>pluginlib</build_depend>
   <depend>tf2</depend>
 

--- a/smacc2_client_library/cl_nav2z/custom_planners/forward_local_planner/package.xml
+++ b/smacc2_client_library/cl_nav2z/custom_planners/forward_local_planner/package.xml
@@ -20,6 +20,7 @@
   <depend>nav2_costmap_2d</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>
+  <build_depend>boost</build_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Without this, compilation can fail with errors like:

    /build/SMACC2-release-release-jazzy-forward_global_planner-3.1.0-2/src/forward_global_planner/forward_global_planner.cpp:28:10:
    fatal error: boost/assign.hpp: No such file or directory
       28 | #include <boost/assign.hpp>
          |          ^~~~~~~~~~~~~~~~~~