### PR TITLE
sm_simple_action_client: Declare dependency on example_interfaces

### DIFF
--- a/smacc2_sm_reference_library/sm_simple_action_client/package.xml
+++ b/smacc2_sm_reference_library/sm_simple_action_client/package.xml
@@ -13,6 +13,7 @@
   <depend>libboost-thread-dev</depend>
 
   <depend>action_tutorials_interfaces</depend>
+  <depend>example_interfaces</depend>
   <depend>smacc2</depend>
   <depend>std_msgs</depend>
 


### PR DESCRIPTION
`example_interfaces` are required in `CMakeLists.txt`, but are missing from `package.xml`.