### PR TITLE
Some CodeQL warning fixes

### DIFF
--- a/.github/workflows/ci-ros-lint.yaml
+++ b/.github/workflows/ci-ros-lint.yaml
@@ -6,6 +6,8 @@ jobs:
   ament_lint:
     name: ament_${{ matrix.linter }}
     runs-on: ubuntu-24.04
+    env:
+      AMENT_CPPCHECK_ALLOW_SLOW_VERSIONS: 1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-sanitizers.yml
+++ b/.github/workflows/ci-sanitizers.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           source /opt/ros/jazzy/setup.bash
-          sudo rosdep init
+          sudo rosdep init || true
           rosdep update
           rosdep install --from-paths . --ignore-src -r -y
 

--- a/.github/workflows/ci-sanitizers.yml
+++ b/.github/workflows/ci-sanitizers.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Install dependencies
         run: |
           source /opt/ros/jazzy/setup.bash
+          sudo rosdep init
+          rosdep update
           rosdep install --from-paths . --ignore-src -r -y
 
       - name: Build with TSan + UBSan

--- a/.github/workflows/ci-sanitizers.yml
+++ b/.github/workflows/ci-sanitizers.yml
@@ -1,7 +1,7 @@
 name: Sanitizers
 
 on:
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   tsan:

--- a/.github/workflows/ci-sanitizers.yml
+++ b/.github/workflows/ci-sanitizers.yml
@@ -1,0 +1,55 @@
+name: Sanitizers
+
+on:
+  pull_request:
+
+jobs:
+  tsan:
+    name: ThreadSanitizer + UBSan
+    runs-on: ubuntu-24.04
+    env:
+      TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
+      UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: jazzy
+
+      - name: Install dependencies
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          rosdep install --from-paths . --ignore-src -r -y
+
+      - name: Build with TSan + UBSan
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          colcon build \
+            --packages-select \
+              smacc2 \
+              smacc2_msgs \
+              cl_ros2_timer \
+              sr_all_events_go \
+              sr_event_countdown \
+              sr_conditional \
+              eg_conditional_generator \
+              eg_random_generator \
+              sm_atomic \
+              sm_cl_ros2_timer_unit_test_1 \
+            --cmake-args \
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+              -DCMAKE_CXX_FLAGS="-fsanitize=thread,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer" \
+              -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread,undefined" \
+              -DBUILD_TESTING=ON
+
+      - name: Run tests
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          source install/setup.bash
+          colcon test \
+            --packages-select sm_atomic sm_cl_ros2_timer_unit_test_1 \
+            --event-handlers console_direct+
+
+      - name: Check results
+        run: colcon test-result --verbose

--- a/.github/workflows/ci-sanitizers.yml
+++ b/.github/workflows/ci-sanitizers.yml
@@ -11,7 +11,7 @@ jobs:
       TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
       UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ros-tooling/setup-ros@v0.7
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           source /opt/ros/jazzy/setup.bash
-          sudo rosdep init
+          sudo rosdep init || true
           rosdep update
           rosdep install --from-paths . --ignore-src -r -y
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ros-tooling/setup-ros@v0.7
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,11 +1,7 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [jazzy]
-  pull_request:
-  schedule:
-    - cron: '30 1 * * 1'
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,59 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [jazzy]
+  pull_request:
+  schedule:
+    - cron: '30 1 * * 1'
+
+jobs:
+  analyze:
+    name: CodeQL Analysis (C++)
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: jazzy
+
+      - name: Install dependencies
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          rosdep install --from-paths . --ignore-src -r -y
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: c-cpp
+          queries: security-and-quality
+
+      - name: Build
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          colcon build \
+            --packages-select \
+              smacc2 \
+              smacc2_msgs \
+              cl_keyboard \
+              cl_ros2_timer \
+              cl_generic_sensor \
+              cl_nav2z \
+              backward_global_planner \
+              backward_local_planner \
+              forward_global_planner \
+              forward_local_planner \
+              nav2z_planners_common \
+              pure_spinning_local_planner \
+              undo_path_global_planner \
+            --cmake-args -DBUILD_TESTING=OFF
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:c-cpp

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Install dependencies
         run: |
           source /opt/ros/jazzy/setup.bash
+          sudo rosdep init
+          rosdep update
           rosdep install --from-paths . --ignore-src -r -y
 
       - name: Initialize CodeQL

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,10 +33,10 @@ repos:
 
   # Python hooks
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v3.15.2
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py311-plus]
 
   - repo: https://github.com/psf/black
     rev: 22.3.0
@@ -69,15 +69,16 @@ repos:
         args: ['-fallback-style=none', '-i']
         exclude: smacc2_sm_reference_library/
 
-  # - repo: local
-  #   hooks:
-  #     - id: ament_cppcheck
-  #       name: ament_cppcheck
-  #       description: Static code analysis of C/C++ files.
-  #       stages: [commit]
-  #       entry: ament_cppcheck
-  #       language: system
-  #       files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
+  - repo: local
+    hooks:
+      - id: ament_cppcheck
+        name: ament_cppcheck
+        description: Static code analysis of C/C++ files.
+        stages: [commit]
+        entry: env AMENT_CPPCHECK_ALLOW_SLOW_VERSIONS=1 ament_cppcheck
+        language: system
+        files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
+        exclude: smacc2_sm_reference_library/
 
   # Maybe use https://github.com/cpplint/cpplint instead
   #- repo: local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ To send us a pull request, please:
 1. Fork the repository.
 2. Modify the source; please focus on the specific change you are contributing.
   If you also reformat all the code, it will be hard for us to focus on your change.
-3. Ensure local tests pass. (`colcon test` and `pre-commit run -a` (requires you to install pre-commit by `sudo apt install pre-commit` on Ubuntu 24.04+)
+3. Ensure local tests pass. (`colcon test` and `pre-commit run -a` (requires you to install pre-commit by `sudo apt install pre-commit` on Ubuntu 24.04+, and to source ROS first: `source /opt/ros/jazzy/setup.bash`)
 4. Commit to your fork using clear commit messages.
 5. Send a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.

--- a/TYPOS.md
+++ b/TYPOS.md
@@ -1,0 +1,64 @@
+# Typo Fix Backlog
+
+Identified by manual audit. All are in comments/strings — no logic changes required.
+Fix as a single dedicated PR after pre-commit / pyupgrade cleanup is merged.
+
+---
+
+## Core `smacc2/`
+
+| File | Line | Wrong | Correct |
+|------|------|-------|---------|
+| `smacc2/include/smacc2/smacc_state_base.hpp` | 419 | `Initializating` | `Initializing` |
+| `smacc2/include/smacc2/impl/smacc_client_behavior_impl.hpp` | 80 | `funcionality` | `functionality` |
+| `smacc2/include/smacc2/impl/smacc_orthogonal_impl.hpp` | 74 | `funcionality` | `functionality` |
+| `smacc2/src/smacc2/client_bases/smacc_ros_launch_client_2.cpp` | 167 | `Aditional` | `Additional` |
+
+---
+
+## `cl_keyboard`
+
+| File | Line | Wrong | Correct |
+|------|------|-------|---------|
+| `cl_keyboard/include/cl_keyboard/cl_keyboard.hpp` | 47 | `funcionality` | `functionality` |
+| `cl_keyboard/include/cl_keyboard/cl_keyboard.hpp` | 47 | `interated` | `integrated` |
+
+---
+
+## `cl_nav2z` — behaviors & components
+
+| File | Line | Wrong | Correct |
+|------|------|-------|---------|
+| `.../client_behaviors/cb_spiral_motion.hpp` | 41 | `stae` | `state` |
+| `.../client_behaviors/cb_spiral_motion.hpp` | 47 | `usag` | `usage` |
+| `.../client_behaviors/cb_spiral_motion.cpp` | 117, 119, 121 | `ellapsed` | `elapsed` (4×) |
+| `.../client_behaviors/cb_position_control_free_space.cpp` | 166 | `cummulated` | `cumulated` |
+| `.../client_behaviors/cb_pure_spinning.cpp` | 75 | `cummulated` | `cumulated` |
+| `.../client_behaviors/cb_save_slam_map.cpp` | 44 | `builded` | `built` |
+| `.../components/waypoints_navigator/cp_waypoints_event_dispatcher.hpp` | 29 | `unuseable` | `unusable` |
+| `.../components/waypoints_navigator/cp_waypoints_event_dispatcher.hpp` | 1603 | `Doygen` | `Doxygen` |
+| `.../components/odom_tracker/cp_odom_tracker.cpp` | 609 | `updatd` | `updated` |
+
+---
+
+## `cl_nav2z` — custom planners
+
+| File | Line | Wrong | Correct |
+|------|------|-------|---------|
+| `backward_global_planner/src/backward_global_planner.cpp` | 73 | `initializating` | `initializing` |
+| `backward_local_planner/include/.../backward_local_planner.hpp` | 91 | `spining` | `spinning` |
+| `backward_local_planner/src/backward_local_planner.cpp` | 237 | `funcionality` | `functionality` |
+| `forward_local_planner/src/forward_local_planner.cpp` | 635 | `funcionality` | `functionality` |
+| `nav2z_planners_common/src/common.cpp` | 42, 43, 52, 57, 68, 74, 83 | `spining` | `spinning` (7×) |
+| `pure_spinning_local_planner/src/pure_spinning_local_planner.cpp` | 186 | `funcionality` | `functionality` |
+| `undo_path_global_planner/src/undo_path_global_planner.cpp` | 91 | `initializating` | `initializing` |
+| `undo_path_global_planner/src/undo_path_global_planner.cpp` | 274 | `POIINT` | `POINT` |
+
+---
+
+## `smacc2_performance_tools`
+
+| File | Line | Wrong | Correct |
+|------|------|-------|---------|
+| `.../st_state_1.hpp` | 26 | `clases` | `classes` |
+| `.../st_state_2.hpp` | 29 | `clases` | `classes` |

--- a/smacc2/CHANGELOG.rst
+++ b/smacc2/CHANGELOG.rst
@@ -3,6 +3,16 @@ Changelog for package smacc2
 
 3.1.0 (2026-05-31)
 -------------------
+### Fixed
+- **Spelling: ``notifyOnStateExiting``** — corrected double-t typo
+  (``notifyOnStateExitting``) in declaration (``smacc_state_machine.hpp``),
+  definition (``smacc_state_machine_impl.hpp``), and call site
+  (``smacc_state_base.hpp``).
+- **Duplicate includes removed** from ``smacc_state_machine_impl.hpp`` — seven
+  headers that were listed twice (no-op under ``#pragma once``, but confusing).
+- **Dead commented-out include removed** from ``smacc_state_machine.hpp`` —
+  ``smacc_event_generator.hpp`` was already included via the impl header.
+
 ### Changed
 - **cl_ros2_timer duration-based API** (`#61 <https://github.com/robosoft-ai/SMACC2/issues/61>`_)
 

--- a/smacc2/include/smacc2/impl/smacc_client_behavior_impl.hpp
+++ b/smacc2/include/smacc2/impl/smacc_client_behavior_impl.hpp
@@ -77,7 +77,7 @@ void ISmaccClientBehavior::requiresComponent(
   {
     RCLCPP_ERROR(
       getLogger(),
-      "Cannot use the requiresComponent funcionality before assigning the client behavior to an "
+      "Cannot use the requiresComponent functionality before assigning the client behavior to an "
       "orthogonal. Try using the OnEntry method to capture required components.");
   }
   else

--- a/smacc2/include/smacc2/impl/smacc_orthogonal_impl.hpp
+++ b/smacc2/include/smacc2/impl/smacc_orthogonal_impl.hpp
@@ -71,7 +71,7 @@ void ISmaccOrthogonal::requiresComponent(SmaccComponentType *& storage)
   {
     RCLCPP_ERROR(
       getLogger(),
-      "Cannot use the requiresComponent funcionality from an orthogonal before onInitialize");
+      "Cannot use the requiresComponent functionality from an orthogonal before onInitialize");
   }
   else
   {

--- a/smacc2/include/smacc2/impl/smacc_state_machine_impl.hpp
+++ b/smacc2/include/smacc2/impl/smacc_state_machine_impl.hpp
@@ -600,7 +600,7 @@ void ISmaccStateMachine::notifyOnRuntimeConfigured(StateType *)
 }
 
 template <typename StateType>
-void ISmaccStateMachine::notifyOnStateExitting(StateType * state)
+void ISmaccStateMachine::notifyOnStateExiting(StateType * state)
 {
   stateMachineCurrentAction = StateMachineInternalAction::STATE_EXITING;
   auto fullname = demangleSymbol(typeid(StateType).name());

--- a/smacc2/include/smacc2/smacc_state_base.hpp
+++ b/smacc2/include/smacc2/smacc_state_base.hpp
@@ -416,7 +416,7 @@ private:
   {
     // finally we go to the derived state onEntry Function
 
-    RCLCPP_DEBUG(getLogger(), "[%s] State object created. Initializating...", STATE_NAME);
+    RCLCPP_DEBUG(getLogger(), "[%s] State object created. Initializing...", STATE_NAME);
     this->getStateMachine().notifyOnStateEntryStart(static_cast<MostDerived *>(this));
 
     RCLCPP_DEBUG_STREAM(

--- a/smacc2/include/smacc2/smacc_state_base.hpp
+++ b/smacc2/include/smacc2/smacc_state_base.hpp
@@ -123,10 +123,10 @@ public:
   void exit()
   {
     auto * derivedThis = static_cast<MostDerived *>(this);
-    // this->getStateMachine().notifyOnStateExitting(derivedThis);
+    // this->getStateMachine().notifyOnStateExiting(derivedThis);
     {
       std::lock_guard<std::recursive_mutex> lock(this->getStateMachine().getMutex());
-      this->getStateMachine().notifyOnStateExitting(derivedThis);
+      this->getStateMachine().notifyOnStateExiting(derivedThis);
       try
       {
         TRACETOOLS_TRACEPOINT(smacc2_state_onExit_start, STATE_NAME);

--- a/smacc2/include/smacc2/smacc_state_machine.hpp
+++ b/smacc2/include/smacc2/smacc_state_machine.hpp
@@ -142,7 +142,7 @@ public:
   void notifyOnRuntimeConfigured(StateType * state);
 
   template <typename StateType>
-  void notifyOnStateExitting(StateType * state);
+  void notifyOnStateExiting(StateType * state);
 
   template <typename StateType>
   void notifyOnStateExited(StateType * state);

--- a/smacc2/src/smacc2/client_bases/smacc_ros_launch_client_2.cpp
+++ b/smacc2/src/smacc2/client_bases/smacc_ros_launch_client_2.cpp
@@ -164,7 +164,7 @@ std::future<std::string> ClRosLaunch2::executeRosLaunch(
     });
 }
 
-/**Aditional functions**/
+/**Additional functions**/
 /////////////////////////////////////////////////////
 
 ProcessInfo runProcess(const char * command)

--- a/smacc2/src/smacc2/client_bases/smacc_ros_launch_client_2.cpp
+++ b/smacc2/src/smacc2/client_bases/smacc_ros_launch_client_2.cpp
@@ -17,8 +17,8 @@
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/
-#include <errno.h>  // Agrega esta inclusión
-#include <fcntl.h>  // Agrega esta inclusión
+#include <errno.h>
+#include <fcntl.h>
 #include <poll.h>
 #include <signal.h>
 #include <stdio.h>
@@ -53,7 +53,7 @@ ClRosLaunch2::~ClRosLaunch2() {}
 void ClRosLaunch2::launch()
 {
   cancellationToken_.store(false);
-  // Iniciar el hilo para la ejecución del lanzamiento
+  // Start the launch execution thread
   this->result_ = /*std::async([this]()*/
                   // {
     executeRosLaunch(packageName_, launchFileName_, [this]() { return cancellationToken_.load(); });
@@ -62,7 +62,7 @@ void ClRosLaunch2::launch()
 
 void ClRosLaunch2::stop()
 {
-  // Establecer la bandera de cancelación
+  // Set the cancellation flag
   cancellationToken_.store(true);
 }
 
@@ -112,14 +112,14 @@ std::future<std::string> ClRosLaunch2::executeRosLaunch(
         }
         else if (bytesRead == 0)
         {
-          // No se han leído más datos
+          // No data available yet
           std::this_thread::sleep_for(
-            std::chrono::milliseconds(100));  // Espera antes de intentar nuevamente
+            std::chrono::milliseconds(100));  // Wait before retrying
         }
         else
         {
-          // Error de lectura
-          RCLCPP_ERROR(rclcpp::get_logger("smacc2"), "Error de lectura en pipe");
+          // Read error
+          RCLCPP_ERROR(rclcpp::get_logger("smacc2"), "Error reading from pipe");
           break;
         }
       }
@@ -158,7 +158,6 @@ std::future<std::string> ClRosLaunch2::executeRosLaunch(
 
       RCLCPP_WARN_STREAM(rclcpp::get_logger("smacc2"), "[ClRosLaunch2] RESULT:\n" << result);
 
-      // Devuelve una std::future con el resultado
       // return std::async(std::launch::async, [result]() { return result; });
       return result;
     });
@@ -170,10 +169,10 @@ std::future<std::string> ClRosLaunch2::executeRosLaunch(
 ProcessInfo runProcess(const char * command)
 {
   ProcessInfo info;
-  info.pid = -1;  // Inicializar el PID a -1 (indicando error)
+  info.pid = -1;  // Initialize PID to -1 (error sentinel)
   info.pipe = nullptr;
 
-  int pipefd[2];  // Descriptor de archivo para el pipe
+  int pipefd[2];  // File descriptors for the pipe
 
   if (pipe(pipefd) == -1)
   {
@@ -185,27 +184,27 @@ ProcessInfo runProcess(const char * command)
 
   if (pid == 0)
   {
-    // Esto se ejecuta en el proceso hijo
-    close(pipefd[0]);                // Cerramos el extremo de lectura del pipe en el proceso hijo
-    dup2(pipefd[1], STDOUT_FILENO);  // Redireccionamos la salida estándar al pipe
-    close(pipefd[1]);                // Cerramos el extremo de escritura del pipe en el proceso hijo
+    // Child process
+    close(pipefd[0]);                // Close read end in child
+    dup2(pipefd[1], STDOUT_FILENO);  // Redirect stdout to pipe
+    close(pipefd[1]);                // Close write end in child
 
-    execl("/bin/sh", "/bin/sh", "-c", command, nullptr);  // Ejecuta el comando dado
+    execl("/bin/sh", "/bin/sh", "-c", command, nullptr);  // Execute the command
 
-    // Si execl retorna, significa que hubo un error
-    std::cerr << "Error al ejecutar el comando: " << command << std::endl;
-    _exit(1);  // Usar _exit para evitar la ejecución de códigos de salida de manejo de errores
+    // execl only returns on error
+    std::cerr << "Error executing command: " << command << std::endl;
+    _exit(1);  // Use _exit to skip atexit handlers
   }
   else if (pid > 0)
   {
-    // Esto se ejecuta en el proceso padre
-    close(pipefd[1]);  // Cerramos el extremo de escritura del pipe en el proceso padre
+    // Parent process
+    close(pipefd[1]);  // Close write end in parent
     info.pid = pid;
-    info.pipe = fdopen(pipefd[0], "r");  // Abrir el descriptor de archivo de lectura en modo texto
+    info.pipe = fdopen(pipefd[0], "r");  // Open read end as text-mode FILE
   }
   else
   {
-    std::cerr << "Error al crear el proceso hijo." << std::endl;
+    std::cerr << "Error creating child process." << std::endl;
   }
 
   return info;
@@ -259,28 +258,3 @@ void killGrandchildren(pid_t originalPid) { killProcessesRecursive(originalPid);
 }  // namespace client_bases
 }  // namespace smacc2
 
-/*=============DOCUMENTATION=================*/
-
-/**************BASH VERSION*******************/
-/*************RECURSIVE KILL******************/
-// #!/bin/bash
-
-// # PID del proceso original (cambia esto al PID que desees)
-// original_pid=1119572
-
-// # Función recursiva para matar a los nietos
-// kill_grandchildren() {
-//   local parent_pid=$1
-//   local children=$(pgrep -P $parent_pid)
-
-//   for child in $children; do
-//     # Matar al hijo (nieto del proceso original)
-//     kill -9 $child
-
-//     # Llamar a la función de manera recursiva para matar a los nietos
-//     kill_grandchildren $child
-//   done
-// }
-
-// # Llamar a la función para matar a los nietos del proceso original
-// kill_grandchildren $original_pid

--- a/smacc2/src/smacc2/client_bases/smacc_ros_launch_client_2.cpp
+++ b/smacc2/src/smacc2/client_bases/smacc_ros_launch_client_2.cpp
@@ -113,8 +113,7 @@ std::future<std::string> ClRosLaunch2::executeRosLaunch(
         else if (bytesRead == 0)
         {
           // No data available yet
-          std::this_thread::sleep_for(
-            std::chrono::milliseconds(100));  // Wait before retrying
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));  // Wait before retrying
         }
         else
         {
@@ -257,4 +256,3 @@ void killProcessesRecursive(pid_t pid)
 void killGrandchildren(pid_t originalPid) { killProcessesRecursive(originalPid); }
 }  // namespace client_bases
 }  // namespace smacc2
-

--- a/smacc2/src/smacc2/signal_detector.cpp
+++ b/smacc2/src/smacc2/signal_detector.cpp
@@ -292,7 +292,8 @@ void SignalDetector::pollOnce()
       auto node = getNode();
       for (auto * updatableClient : this->updatableClients_)
       {
-        auto updatableElementName = demangleType(typeid(*updatableClient)).c_str();
+        auto updatableElementNameStr = demangleType(typeid(*updatableClient));
+        auto updatableElementName = updatableElementNameStr.c_str();
         try
         {
           RCLCPP_DEBUG_STREAM(

--- a/smacc2_client_library/cl_http/CMakeLists.txt
+++ b/smacc2_client_library/cl_http/CMakeLists.txt
@@ -19,8 +19,6 @@ include_directories(
   ${smacc2_INCLUDE_DIRS}
 )
 
-file(GLOB_RECURSE SRC_FILES src *.cpp)
-
 add_library(http_session
   src/cl_http/ssl_http_session.cpp
   src/cl_http/http_session.cpp

--- a/smacc2_client_library/cl_http/include/cl_http/cl_http.hpp
+++ b/smacc2_client_library/cl_http/include/cl_http/cl_http.hpp
@@ -61,13 +61,6 @@ namespace cl_http
 class ClHttp : public smacc2::ISmaccClient
 {
 public:
-  enum class kHttpRequestMethod
-  {
-    GET = static_cast<int>(boost::beast::http::verb::get),
-    POST = static_cast<int>(boost::beast::http::verb::post),
-    PUT = static_cast<int>(boost::beast::http::verb::put),
-  };
-
   using TResponse = http_session_base::TResponse;
 
   explicit ClHttp(const std::string & server, const int & timeout = 1500);

--- a/smacc2_client_library/cl_keyboard/CMakeLists.txt
+++ b/smacc2_client_library/cl_keyboard/CMakeLists.txt
@@ -21,11 +21,8 @@ include_directories(
   ${std_msgs_INCLUDE_DIRS}
 )
 
-file(GLOB_RECURSE SRC_FILES src *.cpp)
-#file(GLOB_RECURSE SRC_FILES "src/*.cpp" "src/client_behaviors/*.cpp")
-
 add_library(${PROJECT_NAME}
-  ${SRC_FILES}
+  src/cl_keyboard/cl_keyboard.cpp
 )
 
 target_link_libraries(${PROJECT_NAME} ${smacc2_LIBRARIES} ${std_msgs_LIBRARIES})

--- a/smacc2_client_library/cl_keyboard/include/cl_keyboard/cl_keyboard.hpp
+++ b/smacc2_client_library/cl_keyboard/include/cl_keyboard/cl_keyboard.hpp
@@ -44,7 +44,7 @@ public:
 
   {
     // We start by creating a topic subscriber component from SMACC2s client core components.
-    // We use this to gain the topic funcionality interated with SMACC and the ability to post smacc events for transitions.
+    // We use this to gain the topic functionality integrated with SMACC and the ability to post smacc events for transitions.
     // We are using it to handle the reception of ros topic messages and to notify the other components in the client.
     this->createComponent<
       smacc2::client_core_components::CpTopicSubscriber<std_msgs::msg::UInt16>, TOrthogonal,

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/cl_moveit2z.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/cl_moveit2z.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <cl_moveit2z/components/cp_motion_planner.hpp>
 #include <cl_moveit2z/components/cp_move_group_interface.hpp>
 #include <smacc2/smacc.hpp>
 
@@ -38,6 +39,7 @@ public:
   void onComponentInitialization()
   {
     this->createComponent<CpMoveGroupInterface, TOrthogonal, TClient>(options_);
+    this->createComponent<CpMotionPlanner, TOrthogonal, TClient>();
   }
 
   inline const moveit::planning_interface::MoveGroupInterface::Options & getOptions() const

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/cl_moveit2z.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/cl_moveit2z.hpp
@@ -20,123 +20,24 @@
 
 #pragma once
 
-//#include <smacc2/smacc_client.h>
-//#include <smacc2/smacc_signal.h>
+#include <cl_moveit2z/components/cp_move_group_interface.hpp>
 #include <smacc2/smacc.hpp>
-
-#include <moveit/move_group_interface/move_group_interface.hpp>
-#include <moveit/planning_scene_interface/planning_scene_interface.hpp>
-
-#include <geometry_msgs/msg/transform.hpp>
-#include <geometry_msgs/msg/vector3.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 namespace cl_moveit2z
 {
-template <typename TSource, typename TOrthogonal>
-struct EvMoveGroupMotionExecutionSucceeded
-: sc::event<EvMoveGroupMotionExecutionSucceeded<TSource, TOrthogonal>>
-{
-};
-
-template <typename TSource, typename TOrthogonal>
-struct EvMoveGroupMotionExecutionFailed
-: sc::event<EvMoveGroupMotionExecutionFailed<TSource, TOrthogonal>>
-{
-};
-
-/*
-moveit_msgs/MoveItErrorCodes
-----------------------------
-int32 SUCCESS=1
-int32 FAILURE=99999
-int32 PLANNING_FAILED=-1
-int32 INVALID_MOTION_PLAN=-2
-int32 MOTION_PLAN_INVALIDATED_BY_ENVIRONMENT_CHANGE=-3
-int32 CONTROL_FAILED=-4
-int32 UNABLE_TO_AQUIRE_SENSOR_DATA=-5
-int32 TIMED_OUT=-6
-int32 PREEMPTED=-7
-int32 START_STATE_IN_COLLISION=-10
-int32 START_STATE_VIOLATES_PATH_CONSTRAINTS=-11
-int32 GOAL_IN_COLLISION=-12
-int32 GOAL_VIOLATES_PATH_CONSTRAINTS=-13
-int32 GOAL_CONSTRAINTS_VIOLATED=-14
-int32 INVALID_GROUP_NAME=-15
-int32 INVALID_GOAL_CONSTRAINTS=-16
-int32 INVALID_ROBOT_STATE=-17
-int32 INVALID_LINK_NAME=-18
-int32 INVALID_OBJECT_NAME=-19
-int32 FRAME_TRANSFORM_FAILURE=-21
-int32 COLLISION_CHECKING_UNAVAILABLE=-22
-int32 ROBOT_STATE_STALE=-23
-int32 SENSOR_INFO_STALE=-24
-int32 NO_IK_SOLUTION=-31
-int32 val
-*/
-
 class ClMoveit2z : public smacc2::ISmaccClient
 {
 public:
-  // this structure contains the default move_group configuration for any arm motion through move_group
-  // the client behavior will override these default values in a copy of this object so that their changes
-  // are not persinstent. In the other hand, if you change this client configuration, the parameters will be persistent.
-  std::shared_ptr<moveit::planning_interface::MoveGroupInterface> moveGroupClientInterface;
-
-  std::shared_ptr<moveit::planning_interface::PlanningSceneInterface> planningSceneInterface;
-
   ClMoveit2z(std::string groupName);
 
   ClMoveit2z(const moveit::planning_interface::MoveGroupInterface::Options & options);
 
   virtual ~ClMoveit2z();
 
-  inline void onInitialize() override
+  template <typename TOrthogonal, typename TClient>
+  void onComponentInitialization()
   {
-    moveGroupClientInterface =
-      std::make_shared<moveit::planning_interface::MoveGroupInterface>(getNode(), options_);
-    planningSceneInterface = std::make_shared<moveit::planning_interface::PlanningSceneInterface>(
-      options_.move_group_namespace);
-  }
-
-  inline void postEventMotionExecutionSucceeded()
-  {
-    RCLCPP_INFO(getLogger(), "[ClMoveit2z] Post Motion Success Event");
-    postEventMotionExecutionSucceeded_();
-  }
-
-  inline void postEventMotionExecutionFailed()
-  {
-    RCLCPP_INFO(getLogger(), "[ClMoveit2z] Post Motion Failure Event");
-    postEventMotionExecutionFailed_();
-  }
-
-  template <typename TOrthogonal, typename TSourceObject>
-  void onStateOrthogonalAllocation()
-  {
-    postEventMotionExecutionSucceeded_ = [=]()
-    {
-      this->onSucceeded_();
-      this->postEvent<EvMoveGroupMotionExecutionSucceeded<TSourceObject, TOrthogonal>>();
-    };
-
-    postEventMotionExecutionFailed_ = [=]()
-    {
-      this->onFailed_();
-      this->postEvent<EvMoveGroupMotionExecutionFailed<TSourceObject, TOrthogonal>>();
-    };
-  }
-
-  template <typename TCallback, typename T>
-  smacc2::SmaccSignalConnection onMotionExecutionSucceeded(TCallback callback, T * object)
-  {
-    return this->getStateMachine()->createSignalConnection(onSucceeded_, callback, object);
-  }
-
-  template <typename TCallback, typename T>
-  smacc2::SmaccSignalConnection onMotionExecutionFailed(TCallback callback, T * object)
-  {
-    return this->getStateMachine()->createSignalConnection(onFailed_, callback, object);
+    this->createComponent<CpMoveGroupInterface, TOrthogonal, TClient>(options_);
   }
 
   inline const moveit::planning_interface::MoveGroupInterface::Options & getOptions() const
@@ -145,13 +46,6 @@ public:
   }
 
 private:
-  std::function<void()> postEventMotionExecutionSucceeded_;
-  std::function<void()> postEventMotionExecutionFailed_;
-
-  smacc2::SmaccSignal<void()> onSucceeded_;
-  smacc2::SmaccSignal<void()> onFailed_;
-
-  // std::string groupName_;
   moveit::planning_interface::MoveGroupInterface::Options options_;
 };
 }  // namespace cl_moveit2z

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/cl_moveit2z.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/cl_moveit2z.hpp
@@ -34,8 +34,8 @@
 namespace cl_moveit2z
 {
 template <typename TSource, typename TOrthogonal>
-struct EvMoveGroupMotionExecutionSucceded
-: sc::event<EvMoveGroupMotionExecutionSucceded<TSource, TOrthogonal>>
+struct EvMoveGroupMotionExecutionSucceeded
+: sc::event<EvMoveGroupMotionExecutionSucceeded<TSource, TOrthogonal>>
 {
 };
 
@@ -99,10 +99,10 @@ public:
       options_.move_group_namespace);
   }
 
-  inline void postEventMotionExecutionSucceded()
+  inline void postEventMotionExecutionSucceeded()
   {
     RCLCPP_INFO(getLogger(), "[ClMoveit2z] Post Motion Success Event");
-    postEventMotionExecutionSucceded_();
+    postEventMotionExecutionSucceeded_();
   }
 
   inline void postEventMotionExecutionFailed()
@@ -114,10 +114,10 @@ public:
   template <typename TOrthogonal, typename TSourceObject>
   void onStateOrthogonalAllocation()
   {
-    postEventMotionExecutionSucceded_ = [=]()
+    postEventMotionExecutionSucceeded_ = [=]()
     {
-      this->onSucceded_();
-      this->postEvent<EvMoveGroupMotionExecutionSucceded<TSourceObject, TOrthogonal>>();
+      this->onSucceeded_();
+      this->postEvent<EvMoveGroupMotionExecutionSucceeded<TSourceObject, TOrthogonal>>();
     };
 
     postEventMotionExecutionFailed_ = [=]()
@@ -128,9 +128,9 @@ public:
   }
 
   template <typename TCallback, typename T>
-  smacc2::SmaccSignalConnection onMotionExecutionSuccedded(TCallback callback, T * object)
+  smacc2::SmaccSignalConnection onMotionExecutionSucceeded(TCallback callback, T * object)
   {
-    return this->getStateMachine()->createSignalConnection(onSucceded_, callback, object);
+    return this->getStateMachine()->createSignalConnection(onSucceeded_, callback, object);
   }
 
   template <typename TCallback, typename T>
@@ -145,10 +145,10 @@ public:
   }
 
 private:
-  std::function<void()> postEventMotionExecutionSucceded_;
+  std::function<void()> postEventMotionExecutionSucceeded_;
   std::function<void()> postEventMotionExecutionFailed_;
 
-  smacc2::SmaccSignal<void()> onSucceded_;
+  smacc2::SmaccSignal<void()> onSucceeded_;
   smacc2::SmaccSignal<void()> onFailed_;
 
   // std::string groupName_;

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_attach_object.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_attach_object.hpp
@@ -22,6 +22,7 @@
 
 #include <cl_moveit2z/cl_moveit2z.hpp>
 #include <cl_moveit2z/components/cp_grasping_objects.hpp>
+#include <cl_moveit2z/components/cp_move_group_interface.hpp>
 #include <moveit_msgs/msg/collision_object.hpp>
 #include <smacc2/smacc.hpp>
 
@@ -58,8 +59,8 @@ public:
    */
   inline void onEntry() override
   {
-    cl_moveit2z::ClMoveit2z * moveGroup;
-    this->requiresClient(moveGroup);
+    cl_moveit2z::CpMoveGroupInterface * cpMoveGroup;
+    this->requiresComponent(cpMoveGroup);
 
     cl_moveit2z::CpGraspingComponent * graspingComponent;
     this->requiresComponent(graspingComponent);
@@ -74,10 +75,10 @@ public:
       targetCollisionObject.operation = moveit_msgs::msg::CollisionObject::ADD;
       targetCollisionObject.header.stamp = getNode()->now();
 
-      moveGroup->planningSceneInterface->applyCollisionObject(targetCollisionObject);
+      cpMoveGroup->planningSceneInterface->applyCollisionObject(targetCollisionObject);
       graspingComponent->currentAttachedObjectName = targetObjectName_;
 
-      moveGroup->moveGroupClientInterface->attachObject(
+      cpMoveGroup->moveGroupClientInterface->attachObject(
         targetObjectName_, graspingComponent->gripperLink_, graspingComponent->fingerTipNames);
 
       this->postSuccessEvent();

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_circular_pivot_motion.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_circular_pivot_motion.hpp
@@ -236,7 +236,7 @@ private:
     {
       if (!tipLink_ || *tipLink_ == "")
       {
-        tipLink_ = this->movegroupClient_->moveGroupClientInterface->getEndEffectorLink();
+        tipLink_ = this->cpMoveGroup_->moveGroupClientInterface->getEndEffectorLink();
       }
 
       RCLCPP_INFO_STREAM(

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_detach_object.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_detach_object.hpp
@@ -22,6 +22,7 @@
 
 #include <cl_moveit2z/cl_moveit2z.hpp>
 #include <cl_moveit2z/components/cp_grasping_objects.hpp>
+#include <cl_moveit2z/components/cp_move_group_interface.hpp>
 #include <smacc2/smacc.hpp>
 
 namespace cl_moveit2z
@@ -48,8 +49,8 @@ public:
     cl_moveit2z::CpGraspingComponent * graspingComponent;
     this->requiresComponent(graspingComponent);
 
-    cl_moveit2z::ClMoveit2z * moveGroupClient;
-    this->requiresClient(moveGroupClient);
+    cl_moveit2z::CpMoveGroupInterface * cpMoveGroup;
+    this->requiresComponent(cpMoveGroup);
 
     if (graspingComponent->currentAttachedObjectName)
     {
@@ -57,8 +58,8 @@ public:
         getLogger(),
         "[CbDetachObject] Detaching object: " << *(graspingComponent->currentAttachedObjectName));
 
-      auto & planningSceneInterface = moveGroupClient->planningSceneInterface;
-      auto res = moveGroupClient->moveGroupClientInterface->detachObject(
+      auto & planningSceneInterface = cpMoveGroup->planningSceneInterface;
+      auto res = cpMoveGroup->moveGroupClientInterface->detachObject(
         *(graspingComponent->currentAttachedObjectName));
 
       planningSceneInterface->removeCollisionObjects(

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_end_effector_rotate.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_end_effector_rotate.hpp
@@ -52,10 +52,10 @@ public:
 
     int attempts = 3;
 
-    this->requiresClient(movegroupClient_);
+    this->requiresComponent(cpMoveGroup_);
     if (!tipLink_)
     {
-      tipLink_ = this->movegroupClient_->moveGroupClientInterface->getEndEffectorLink();
+      tipLink_ = this->cpMoveGroup_->moveGroupClientInterface->getEndEffectorLink();
       RCLCPP_WARN_STREAM(
         getLogger(),
         "[" << getName() << "] tip unspecified, using default end effector: " << *tipLink_);
@@ -65,8 +65,7 @@ public:
     {
       try
       {
-        auto pivotFrameName =
-          this->movegroupClient_->moveGroupClientInterface->getEndEffectorLink();
+        auto pivotFrameName = this->cpMoveGroup_->moveGroupClientInterface->getEndEffectorLink();
 
         if (tfListener != nullptr)
         {

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_move_end_effector.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_move_end_effector.hpp
@@ -24,6 +24,7 @@
 #include <cl_moveit2z/cl_moveit2z.hpp>
 #include <cl_moveit2z/common.hpp>
 #include <cl_moveit2z/components/cp_motion_planner.hpp>
+#include <cl_moveit2z/components/cp_move_group_interface.hpp>
 #include <cl_moveit2z/components/cp_trajectory_executor.hpp>
 #include <future>
 #include <smacc2/smacc_asynchronous_client_behavior.hpp>
@@ -50,7 +51,7 @@ public:
 
   virtual void onEntry() override
   {
-    this->requiresClient(movegroupClient_);
+    this->requiresComponent(cpMoveGroup_);
 
     if (this->group_)
     {
@@ -65,7 +66,7 @@ public:
     {
       RCLCPP_DEBUG(
         getLogger(), "[CbMoveEndEfector] new thread started to move absolute end effector");
-      this->moveToAbsolutePose(*(movegroupClient_->moveGroupClientInterface), targetPose);
+      this->moveToAbsolutePose(*(cpMoveGroup_->moveGroupClientInterface), targetPose);
       RCLCPP_DEBUG(
         getLogger(), "[CbMoveEndEfector] to move absolute end effector thread destroyed");
     }
@@ -193,19 +194,19 @@ protected:
       // Post events
       if (executionSuccess)
       {
-        movegroupClient_->postEventMotionExecutionSucceeded();
+        cpMoveGroup_->postEventMotionExecutionSucceeded();
         this->postSuccessEvent();
       }
       else
       {
-        movegroupClient_->postEventMotionExecutionFailed();
+        cpMoveGroup_->postEventMotionExecutionFailed();
         this->postFailureEvent();
       }
     }
     else
     {
       RCLCPP_INFO(getLogger(), "[CbMoveEndEffector] planning failed, skipping execution");
-      movegroupClient_->postEventMotionExecutionFailed();
+      cpMoveGroup_->postEventMotionExecutionFailed();
       this->postFailureEvent();
     }
 
@@ -215,6 +216,6 @@ protected:
     return success;
   }
 
-  ClMoveit2z * movegroupClient_;
+  CpMoveGroupInterface * cpMoveGroup_ = nullptr;
 };
 }  // namespace cl_moveit2z

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_move_end_effector.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_move_end_effector.hpp
@@ -193,7 +193,7 @@ protected:
       // Post events
       if (executionSuccess)
       {
-        movegroupClient_->postEventMotionExecutionSucceded();
+        movegroupClient_->postEventMotionExecutionSucceeded();
         this->postSuccessEvent();
       }
       else

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_move_end_effector_trajectory.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_move_end_effector_trajectory.hpp
@@ -25,6 +25,7 @@
 #include <cl_moveit2z/cl_moveit2z.hpp>
 #include <cl_moveit2z/common.hpp>
 #include <cl_moveit2z/components/cp_joint_space_trajectory_planner.hpp>
+#include <cl_moveit2z/components/cp_move_group_interface.hpp>
 #include <cl_moveit2z/components/cp_tf_listener.hpp>
 #include <cl_moveit2z/components/cp_trajectory_executor.hpp>
 #include <cl_moveit2z/components/cp_trajectory_history.hpp>
@@ -102,14 +103,14 @@ public:
     postMotionExecutionFailureEvents = [this]
     {
       RCLCPP_INFO_STREAM(getLogger(), "[" << this->getName() << "] motion execution failed");
-      movegroupClient_->postEventMotionExecutionFailed();
+      cpMoveGroup_->postEventMotionExecutionFailed();
       this->postEvent<EvMoveGroupMotionExecutionFailed<TSourceObject, TOrthogonal>>();
     };
   }
 
   virtual void onEntry() override
   {
-    this->requiresClient(movegroupClient_);
+    this->requiresComponent(cpMoveGroup_);
 
     // Get optional components for visualization
     CpTrajectoryVisualizer * trajectoryVisualizer = nullptr;
@@ -167,7 +168,7 @@ public:
         trajectoryHistory->pushTrajectory(this->getName(), computedTrajectory, error);
       }
 
-      movegroupClient_->postEventMotionExecutionFailed();
+      cpMoveGroup_->postEventMotionExecutionFailed();
       this->postFailureEvent();
 
       if (errorcode == ComputeJointTrajectoryErrorCode::JOINT_TRAJECTORY_DISCONTINUITY)
@@ -271,8 +272,8 @@ protected:
       // LEGACY IMPLEMENTATION (keep for backward compatibility)
       RCLCPP_INFO_STREAM(getLogger(), "[" << getName() << "] getting current state.. waiting");
 
-      auto currentState = movegroupClient_->moveGroupClientInterface->getCurrentState(100);
-      auto groupname = movegroupClient_->moveGroupClientInterface->getName();
+      auto currentState = cpMoveGroup_->moveGroupClientInterface->getCurrentState(100);
+      auto groupname = cpMoveGroup_->moveGroupClientInterface->getName();
 
       RCLCPP_INFO_STREAM(getLogger(), "[" << getName() << "] getting joint names");
       auto currentjointnames =
@@ -280,7 +281,7 @@ protected:
 
       if (!tipLink_ || *tipLink_ == "")
       {
-        tipLink_ = movegroupClient_->moveGroupClientInterface->getEndEffectorLink();
+        tipLink_ = cpMoveGroup_->moveGroupClientInterface->getEndEffectorLink();
       }
 
       std::vector<double> jointPositions;
@@ -503,7 +504,7 @@ protected:
         "execution (consider adding CpTrajectoryExecutor component)");
 
       auto executionResult =
-        this->movegroupClient_->moveGroupClientInterface->execute(computedJointTrajectory);
+        this->cpMoveGroup_->moveGroupClientInterface->execute(computedJointTrajectory);
       executionSuccess = (executionResult == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
 
       RCLCPP_INFO(
@@ -515,7 +516,7 @@ protected:
     if (executionSuccess)
     {
       RCLCPP_INFO_STREAM(getLogger(), "[" << this->getName() << "] motion execution succeeded");
-      movegroupClient_->postEventMotionExecutionSucceeded();
+      cpMoveGroup_->postEventMotionExecutionSucceeded();
       this->postSuccessEvent();
     }
     else
@@ -579,7 +580,7 @@ protected:
 
   std::vector<geometry_msgs::msg::PoseStamped> endEffectorTrajectory_;
 
-  ClMoveit2z * movegroupClient_ = nullptr;
+  CpMoveGroupInterface * cpMoveGroup_ = nullptr;
 
   visualization_msgs::msg::MarkerArray beahiorMarkers_;
 
@@ -594,7 +595,7 @@ protected:
     {
       if (!tipLink_ || *tipLink_ == "")
       {
-        tipLink_ = this->movegroupClient_->moveGroupClientInterface->getEndEffectorLink();
+        tipLink_ = this->cpMoveGroup_->moveGroupClientInterface->getEndEffectorLink();
       }
 
       if (tfListener != nullptr)

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_move_end_effector_trajectory.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_move_end_effector_trajectory.hpp
@@ -515,7 +515,7 @@ protected:
     if (executionSuccess)
     {
       RCLCPP_INFO_STREAM(getLogger(), "[" << this->getName() << "] motion execution succeeded");
-      movegroupClient_->postEventMotionExecutionSucceded();
+      movegroupClient_->postEventMotionExecutionSucceeded();
       this->postSuccessEvent();
     }
     else

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_move_joints.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_move_joints.hpp
@@ -213,7 +213,7 @@ protected:
         RCLCPP_INFO_STREAM(
           getLogger(),
           "[" << this->getName() << "] motion execution succeeded. Throwing success event.");
-        movegroupClient_->postEventMotionExecutionSucceded();
+        movegroupClient_->postEventMotionExecutionSucceeded();
         this->postSuccessEvent();
       }
       else

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_move_joints.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_move_joints.hpp
@@ -28,6 +28,7 @@
 
 #include <cl_moveit2z/cl_moveit2z.hpp>
 #include <cl_moveit2z/components/cp_motion_planner.hpp>
+#include <cl_moveit2z/components/cp_move_group_interface.hpp>
 #include <cl_moveit2z/components/cp_trajectory_executor.hpp>
 #include <smacc2/smacc_asynchronous_client_behavior.hpp>
 
@@ -49,7 +50,7 @@ public:
 
   virtual void onEntry() override
   {
-    this->requiresClient(movegroupClient_);
+    this->requiresComponent(cpMoveGroup_);
 
     if (this->group_)
     {
@@ -59,7 +60,7 @@ public:
     }
     else
     {
-      this->moveJoints(*movegroupClient_->moveGroupClientInterface);
+      this->moveJoints(*cpMoveGroup_->moveGroupClientInterface);
     }
   }
 
@@ -94,7 +95,7 @@ protected:
     if (jointValueTarget_.size() == 0)
     {
       RCLCPP_WARN(getLogger(), "[CbMoveJoints] No joint value specified. Skipping planning call.");
-      movegroupClient_->postEventMotionExecutionFailed();
+      cpMoveGroup_->postEventMotionExecutionFailed();
       this->postFailureEvent();
       return;
     }
@@ -213,14 +214,14 @@ protected:
         RCLCPP_INFO_STREAM(
           getLogger(),
           "[" << this->getName() << "] motion execution succeeded. Throwing success event.");
-        movegroupClient_->postEventMotionExecutionSucceeded();
+        cpMoveGroup_->postEventMotionExecutionSucceeded();
         this->postSuccessEvent();
       }
       else
       {
         RCLCPP_WARN_STREAM(
           getLogger(), "[" << this->getName() << "] motion execution failed. Throwing fail event.");
-        movegroupClient_->postEventMotionExecutionFailed();
+        cpMoveGroup_->postEventMotionExecutionFailed();
         this->postFailureEvent();
       }
     }
@@ -231,11 +232,11 @@ protected:
         getLogger(), "[" << this->getName() << "] planning failed. Throwing fail event."
                          << std::endl
                          << statestr);
-      movegroupClient_->postEventMotionExecutionFailed();
+      cpMoveGroup_->postEventMotionExecutionFailed();
       this->postFailureEvent();
     }
   }
 
-  ClMoveit2z * movegroupClient_;
+  CpMoveGroupInterface * cpMoveGroup_ = nullptr;
 };
 }  // namespace cl_moveit2z

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_undo_last_trajectory.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/client_behaviors/cb_undo_last_trajectory.hpp
@@ -38,7 +38,7 @@ public:
   {
     CpTrajectoryHistory * trajectoryHistory;
     this->requiresComponent(trajectoryHistory);
-    this->requiresClient(movegroupClient_);
+    this->requiresComponent(cpMoveGroup_);
 
     if (trajectoryHistory->getLastTrajectory(backIndex_, trajectory))
     {

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/components/cp_joint_space_trajectory_planner.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/components/cp_joint_space_trajectory_planner.hpp
@@ -22,7 +22,7 @@
 
 #include <smacc2/component.hpp>
 
-#include <cl_moveit2z/cl_moveit2z.hpp>
+#include <cl_moveit2z/components/cp_move_group_interface.hpp>
 
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <moveit_msgs/msg/robot_trajectory.hpp>
@@ -102,7 +102,7 @@ public:
    */
   inline void onInitialize() override
   {
-    this->requiresClient(moveit2zClient_);
+    this->requiresComponent(cpMoveGroupInterface_);
 
     // Create IK service client
     ikClient_ = getNode()->create_client<moveit_msgs::srv::GetPositionIK>("/compute_ik");
@@ -131,16 +131,16 @@ public:
       return result;
     }
 
-    if (!moveit2zClient_)
+    if (!cpMoveGroupInterface_)
     {
-      result.errorMessage = "ClMoveit2z client not available";
+      result.errorMessage = "CpMoveGroupInterface component not available";
       RCLCPP_ERROR(getLogger(), "[CpJointSpaceTrajectoryPlanner] %s", result.errorMessage.c_str());
       return result;
     }
 
     try
     {
-      auto & moveGroup = moveit2zClient_->moveGroupClientInterface;
+      auto & moveGroup = cpMoveGroupInterface_->moveGroupClientInterface;
 
       // Get current robot state
       RCLCPP_INFO(
@@ -339,7 +339,7 @@ public:
   }
 
 private:
-  ClMoveit2z * moveit2zClient_ = nullptr;
+  CpMoveGroupInterface * cpMoveGroupInterface_ = nullptr;
   rclcpp::Client<moveit_msgs::srv::GetPositionIK>::SharedPtr ikClient_;
 };
 

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/components/cp_motion_planner.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/components/cp_motion_planner.hpp
@@ -22,7 +22,7 @@
 
 #include <smacc2/component.hpp>
 
-#include <cl_moveit2z/cl_moveit2z.hpp>
+#include <cl_moveit2z/components/cp_move_group_interface.hpp>
 
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <moveit/move_group_interface/move_group_interface.hpp>
@@ -87,7 +87,7 @@ public:
    */
   inline void onInitialize() override
   {
-    this->requiresClient(moveit2zClient_);
+    this->requiresComponent(cpMoveGroupInterface_);
     RCLCPP_INFO(getLogger(), "[CpMotionPlanner] Component initialized");
   }
 
@@ -105,14 +105,14 @@ public:
   {
     PlanningResult result;
 
-    if (!moveit2zClient_)
+    if (!cpMoveGroupInterface_)
     {
-      result.errorMessage = "ClMoveit2z client not available";
+      result.errorMessage = "CpMoveGroupInterface component not available";
       RCLCPP_ERROR(getLogger(), "[CpMotionPlanner] %s", result.errorMessage.c_str());
       return result;
     }
 
-    auto & moveGroup = moveit2zClient_->moveGroupClientInterface;
+    auto & moveGroup = cpMoveGroupInterface_->moveGroupClientInterface;
 
     try
     {
@@ -178,9 +178,9 @@ public:
   {
     PlanningResult result;
 
-    if (!moveit2zClient_)
+    if (!cpMoveGroupInterface_)
     {
-      result.errorMessage = "ClMoveit2z client not available";
+      result.errorMessage = "CpMoveGroupInterface component not available";
       RCLCPP_ERROR(getLogger(), "[CpMotionPlanner] %s", result.errorMessage.c_str());
       return result;
     }
@@ -192,7 +192,7 @@ public:
       return result;
     }
 
-    auto & moveGroup = moveit2zClient_->moveGroupClientInterface;
+    auto & moveGroup = cpMoveGroupInterface_->moveGroupClientInterface;
 
     try
     {
@@ -246,9 +246,9 @@ public:
   {
     PlanningResult result;
 
-    if (!moveit2zClient_)
+    if (!cpMoveGroupInterface_)
     {
-      result.errorMessage = "ClMoveit2z client not available";
+      result.errorMessage = "CpMoveGroupInterface component not available";
       RCLCPP_ERROR(getLogger(), "[CpMotionPlanner] %s", result.errorMessage.c_str());
       return result;
     }
@@ -260,7 +260,7 @@ public:
       return result;
     }
 
-    auto & moveGroup = moveit2zClient_->moveGroupClientInterface;
+    auto & moveGroup = cpMoveGroupInterface_->moveGroupClientInterface;
 
     try
     {
@@ -310,13 +310,13 @@ public:
    */
   inline moveit::core::RobotStatePtr getCurrentState(double waitTime = 1.0)
   {
-    if (!moveit2zClient_)
+    if (!cpMoveGroupInterface_)
     {
-      RCLCPP_ERROR(getLogger(), "[CpMotionPlanner] ClMoveit2z client not available");
+      RCLCPP_ERROR(getLogger(), "[CpMotionPlanner] CpMoveGroupInterface component not available");
       return nullptr;
     }
 
-    auto & moveGroup = moveit2zClient_->moveGroupClientInterface;
+    auto & moveGroup = cpMoveGroupInterface_->moveGroupClientInterface;
 
     try
     {
@@ -330,7 +330,7 @@ public:
   }
 
 private:
-  ClMoveit2z * moveit2zClient_ = nullptr;
+  CpMoveGroupInterface * cpMoveGroupInterface_ = nullptr;
 
   /**
    * @brief Apply planning options to MoveGroupInterface

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/components/cp_move_group_interface.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/components/cp_move_group_interface.hpp
@@ -1,0 +1,117 @@
+// Copyright 2025 Robosoft Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*****************************************************************************************************************
+ *
+ * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
+ *
+ *****************************************************************************************************************/
+
+#pragma once
+
+#include <smacc2/smacc.hpp>
+
+#include <moveit/move_group_interface/move_group_interface.hpp>
+#include <moveit/planning_scene_interface/planning_scene_interface.hpp>
+
+#include <geometry_msgs/msg/transform.hpp>
+#include <geometry_msgs/msg/vector3.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+namespace cl_moveit2z
+{
+template <typename TSource, typename TOrthogonal>
+struct EvMoveGroupMotionExecutionSucceeded
+: sc::event<EvMoveGroupMotionExecutionSucceeded<TSource, TOrthogonal>>
+{
+};
+
+template <typename TSource, typename TOrthogonal>
+struct EvMoveGroupMotionExecutionFailed
+: sc::event<EvMoveGroupMotionExecutionFailed<TSource, TOrthogonal>>
+{
+};
+
+class CpMoveGroupInterface : public smacc2::ISmaccComponent
+{
+public:
+  std::shared_ptr<moveit::planning_interface::MoveGroupInterface> moveGroupClientInterface;
+  std::shared_ptr<moveit::planning_interface::PlanningSceneInterface> planningSceneInterface;
+
+  explicit CpMoveGroupInterface(
+    const moveit::planning_interface::MoveGroupInterface::Options & options)
+  : options_(options)
+  {
+  }
+
+  inline void onInitialize() override
+  {
+    moveGroupClientInterface =
+      std::make_shared<moveit::planning_interface::MoveGroupInterface>(getNode(), options_);
+    planningSceneInterface = std::make_shared<moveit::planning_interface::PlanningSceneInterface>(
+      options_.move_group_namespace);
+    RCLCPP_INFO(getLogger(), "[CpMoveGroupInterface] MoveGroupInterface initialized");
+  }
+
+  template <typename TOrthogonal, typename TSourceObject>
+  void onStateOrthogonalAllocation()
+  {
+    postEventMotionExecutionSucceeded_ = [=]()
+    {
+      this->onSucceeded_();
+      this->postEvent<EvMoveGroupMotionExecutionSucceeded<TSourceObject, TOrthogonal>>();
+    };
+
+    postEventMotionExecutionFailed_ = [=]()
+    {
+      this->onFailed_();
+      this->postEvent<EvMoveGroupMotionExecutionFailed<TSourceObject, TOrthogonal>>();
+    };
+  }
+
+  inline void postEventMotionExecutionSucceeded()
+  {
+    RCLCPP_INFO(getLogger(), "[CpMoveGroupInterface] Post Motion Success Event");
+    postEventMotionExecutionSucceeded_();
+  }
+
+  inline void postEventMotionExecutionFailed()
+  {
+    RCLCPP_INFO(getLogger(), "[CpMoveGroupInterface] Post Motion Failure Event");
+    postEventMotionExecutionFailed_();
+  }
+
+  template <typename TCallback, typename T>
+  smacc2::SmaccSignalConnection onMotionExecutionSucceeded(TCallback callback, T * object)
+  {
+    return this->getStateMachine()->createSignalConnection(onSucceeded_, callback, object);
+  }
+
+  template <typename TCallback, typename T>
+  smacc2::SmaccSignalConnection onMotionExecutionFailed(TCallback callback, T * object)
+  {
+    return this->getStateMachine()->createSignalConnection(onFailed_, callback, object);
+  }
+
+private:
+  std::function<void()> postEventMotionExecutionSucceeded_;
+  std::function<void()> postEventMotionExecutionFailed_;
+
+  smacc2::SmaccSignal<void()> onSucceeded_;
+  smacc2::SmaccSignal<void()> onFailed_;
+
+  moveit::planning_interface::MoveGroupInterface::Options options_;
+};
+
+}  // namespace cl_moveit2z

--- a/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/components/cp_trajectory_executor.hpp
+++ b/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/components/cp_trajectory_executor.hpp
@@ -22,7 +22,7 @@
 
 #include <smacc2/component.hpp>
 
-#include <cl_moveit2z/cl_moveit2z.hpp>
+#include <cl_moveit2z/components/cp_move_group_interface.hpp>
 #include <cl_moveit2z/components/cp_trajectory_history.hpp>
 
 #include <moveit/move_group_interface/move_group_interface.hpp>
@@ -84,7 +84,7 @@ public:
    */
   inline void onInitialize() override
   {
-    this->requiresClient(moveit2zClient_);
+    this->requiresComponent(cpMoveGroupInterface_);
 
     // CpTrajectoryHistory is optional but recommended
     this->requiresComponent(trajectoryHistory_, smacc2::ComponentRequirement::SOFT);
@@ -116,14 +116,14 @@ public:
   {
     ExecutionResult result;
 
-    if (!moveit2zClient_)
+    if (!cpMoveGroupInterface_)
     {
-      result.errorMessage = "ClMoveit2z client not available";
+      result.errorMessage = "CpMoveGroupInterface component not available";
       RCLCPP_ERROR(getLogger(), "[CpTrajectoryExecutor] %s", result.errorMessage.c_str());
       return result;
     }
 
-    auto & moveGroup = moveit2zClient_->moveGroupClientInterface;
+    auto & moveGroup = cpMoveGroupInterface_->moveGroupClientInterface;
 
     try
     {
@@ -198,13 +198,13 @@ public:
    */
   inline void cancel()
   {
-    if (!moveit2zClient_)
+    if (!cpMoveGroupInterface_)
     {
-      RCLCPP_ERROR(getLogger(), "[CpTrajectoryExecutor] Cannot cancel: client not available");
+      RCLCPP_ERROR(getLogger(), "[CpTrajectoryExecutor] Cannot cancel: component not available");
       return;
     }
 
-    auto & moveGroup = moveit2zClient_->moveGroupClientInterface;
+    auto & moveGroup = cpMoveGroupInterface_->moveGroupClientInterface;
 
     try
     {
@@ -226,7 +226,7 @@ public:
   inline CpTrajectoryHistory * getTrajectoryHistory() { return trajectoryHistory_; }
 
 private:
-  ClMoveit2z * moveit2zClient_ = nullptr;
+  CpMoveGroupInterface * cpMoveGroupInterface_ = nullptr;
   CpTrajectoryHistory * trajectoryHistory_ = nullptr;
 
   /**

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors/cb_rotate.hpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors/cb_rotate.hpp
@@ -19,8 +19,6 @@
  ******************************************************************************************************************/
 #pragma once
 
-#include <tf2_ros/buffer.h>
-
 #include "cb_nav2z_client_behavior_base.hpp"
 
 namespace cl_nav2z
@@ -39,9 +37,5 @@ public:
   CbRotate(float rotate_degree, cl_nav2z::SpinningPlanner spinning_planner);
 
   void onEntry() override;
-
-private:
-  //TODO: replace this with the Pose Component in the same way it is done in the CbAbsoluteRotateBehavior
-  std::shared_ptr<tf2_ros::Buffer> listener;
 };
 }  // namespace cl_nav2z

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors/cb_spiral_motion.hpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors/cb_spiral_motion.hpp
@@ -38,13 +38,13 @@ struct CbSpiralMotionOptions
   std::optional<float> finalRadius = 20.0f;  //meters
 };
 
-/* a basic client behavior has a simple onEntry and onExit functions. When we enter into a stae we call onEntry.
+/* a basic client behavior has a simple onEntry and onExit functions. When we enter into a state we call onEntry.
 This client behavior is asynchronous so that onEntry returns immediately, it opens a thread to run the behavior*/
 struct CbSpiralMotion : public smacc2::SmaccAsyncClientBehavior
 {
 public:
   //
-  // constructor, we accept an empty usag of the behavior, but also any other combination of parameters
+  // constructor, we accept an empty usage of the behavior, but also any other combination of parameters
   CbSpiralMotion(std::optional<CbSpiralMotionOptions> options = std::nullopt);
 
   void onEntry() override;

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/components/waypoints_navigator/cp_waypoints_event_dispatcher.hpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/components/waypoints_navigator/cp_waypoints_event_dispatcher.hpp
@@ -26,7 +26,7 @@ namespace cl_nav2z
 
 /// @cond
 // The purpose of the cond and endcond tags seen above and below in this file are there to prevent doxygen from indexing the 256 events
-// below which makes the documentation produced unuseable.
+// below which makes the documentation produced unusable.
 
 {
 template <typename TSource, typename TOrthogonal>
@@ -1600,7 +1600,7 @@ void configurePostEvWaypoint(
 template <typename TDerived, typename TOrthogonal>
 void WaypointEventDispatcher::initialize(ClNav2Z * client)
 {
-  // Doygen cond tag
+  // Doxygen cond tag
   /// @cond
   this->client_ = client;
   configurePostEvWaypoint<EvWaypoint0<TDerived, TOrthogonal>>(postWaypointFn, this, 0);

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/components/waypoints_navigator/cp_waypoints_navigator.hpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/components/waypoints_navigator/cp_waypoints_navigator.hpp
@@ -69,9 +69,9 @@ public:
 
   void stopWaitingResult();
 
-  smacc2::SmaccSignal<void()> onNavigationRequestSucceded;
-  smacc2::SmaccSignal<void()> onNavigationRequestAborted;
-  smacc2::SmaccSignal<void()> onNavigationRequestCancelled;
+  smacc2::SmaccSignal<void()> onNavigationRequestSucceeded_;
+  smacc2::SmaccSignal<void()> onNavigationRequestAborted_;
+  smacc2::SmaccSignal<void()> onNavigationRequestCancelled_;
 
 private:
   void onNavigationResult(const components::CpNav2ActionInterface::WrappedResult & r);
@@ -80,7 +80,7 @@ private:
   void onGoalCancelled(const components::CpNav2ActionInterface::WrappedResult & /*res*/);
   void onGoalAborted(const components::CpNav2ActionInterface::WrappedResult & /*res*/);
 
-  smacc2::SmaccSignalConnection succeddedNav2ZClientConnection_;
+  smacc2::SmaccSignalConnection succeededNav2ZClientConnection_;
   smacc2::SmaccSignalConnection abortedNav2ZClientConnection_;
   smacc2::SmaccSignalConnection cancelledNav2ZClientConnection_;
 };

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_position_control_free_space.cpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_position_control_free_space.cpp
@@ -163,7 +163,7 @@ void CbPositionControlFreeSpace::onEntry()
 
       // RCLCPP_INFO_STREAM(getLogger(), "[" << getName() << "] delta angle: "
       // << deltaAngle); RCLCPP_INFO_STREAM(getLogger(), "[" << getName() << "]
-      // cummulated angle: " << countAngle); RCLCPP_INFO_STREAM(getLogger(), "["
+      // cumulated angle: " << countAngle); RCLCPP_INFO_STREAM(getLogger(), "["
       // << getName() << "] k_betta_: " << k_betta_);
 
       // RCLCPP_INFO_STREAM(

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_pure_spinning.cpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_pure_spinning.cpp
@@ -72,7 +72,7 @@ void CbPureSpinning::onEntry()
       std::min(std::max(omega, -fabs(max_angular_yaw_speed_)), fabs(max_angular_yaw_speed_));
 
     RCLCPP_INFO_STREAM(getLogger(), "[" << getName() << "] delta angle: " << deltaAngle);
-    RCLCPP_INFO_STREAM(getLogger(), "[" << getName() << "] cummulated angle: " << countAngle);
+    RCLCPP_INFO_STREAM(getLogger(), "[" << getName() << "] cumulated angle: " << countAngle);
     RCLCPP_INFO_STREAM(getLogger(), "[" << getName() << "] k_betta_: " << k_betta_);
 
     RCLCPP_INFO_STREAM(

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_save_slam_map.cpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_save_slam_map.cpp
@@ -41,7 +41,7 @@ CbSaveSlamMap::CbSaveSlamMap() : CbServiceCall("/map_saver/save_map", getRequest
 
   // map_name.data = "saved_map";
   // auto request = getRequest(map_name);
-  // RCLCPP_INFO_STREAM(getLogger(), "Save Slam Map builded");
+  // RCLCPP_INFO_STREAM(getLogger(), "Save Slam Map built");
 }
 
 // void onEntry() override {}

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_spiral_motion.cpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_spiral_motion.cpp
@@ -93,7 +93,7 @@ void CbSpiralMotion::onEntry()
   {
     auto current_time = getNode()->now() - start_time;
 
-    cmd_vel.linear.x += linearAceleration * dt;
+    cmd_vel.linear.x += static_cast<double>(linearAceleration) * dt;
     if (cmd_vel.linear.x > maxLinearVelocity)
     {
       cmd_vel.linear.x = maxLinearVelocity;

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_spiral_motion.cpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_spiral_motion.cpp
@@ -101,9 +101,9 @@ void CbSpiralMotion::onEntry()
 
     // cmd_vel.angular.z -= signVal * angularAcceleration * dt;
 
-    float ellapsedTimeFactor = current_time.seconds() / spiralMotionDuration.seconds();
-    cmd_vel.angular.z = initialAngularVelocity * (1.0f - ellapsedTimeFactor) +
-                        finalAngularVelocity * ellapsedTimeFactor;
+    float elapsedTimeFactor = current_time.seconds() / spiralMotionDuration.seconds();
+    cmd_vel.angular.z = initialAngularVelocity * (1.0f - elapsedTimeFactor) +
+                        finalAngularVelocity * elapsedTimeFactor;
 
     RCLCPP_INFO(
       getLogger(), "[CbSpiralMotion] cmd_vel.linear.x = %f, cmd_vel.angular.z = %f",
@@ -114,11 +114,11 @@ void CbSpiralMotion::onEntry()
 
     auto now = getNode()->now();
 
-    rclcpp::Duration ellapsed = now - start_time;
+    rclcpp::Duration elapsed = now - start_time;
     RCLCPP_INFO_STREAM(
-      getLogger(), "[CbSpiralMotion] ellapsed time: " << ellapsed.seconds() << ", total duration: "
+      getLogger(), "[CbSpiralMotion] elapsed time: " << elapsed.seconds() << ", total duration: "
                                                       << spiralMotionDuration.seconds());
-    if (ellapsed > spiralMotionDuration)
+    if (elapsed > spiralMotionDuration)
     {
       RCLCPP_INFO_STREAM(getLogger(), "[CbSpiralMotion] spiralMotionDuration reached");
       end_condition = true;

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_spiral_motion.cpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_spiral_motion.cpp
@@ -117,7 +117,7 @@ void CbSpiralMotion::onEntry()
     rclcpp::Duration elapsed = now - start_time;
     RCLCPP_INFO_STREAM(
       getLogger(), "[CbSpiralMotion] elapsed time: " << elapsed.seconds() << ", total duration: "
-                                                      << spiralMotionDuration.seconds());
+                                                     << spiralMotionDuration.seconds());
     if (elapsed > spiralMotionDuration)
     {
       RCLCPP_INFO_STREAM(getLogger(), "[CbSpiralMotion] spiralMotionDuration reached");

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/components/odom_tracker/cp_odom_tracker.cpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/components/odom_tracker/cp_odom_tracker.cpp
@@ -606,7 +606,7 @@ void CpOdomTracker::update()
 {
   RCLCPP_INFO(getLogger(), "odom_tracker update");
   auto pose = robotPose_->toPoseStampedMsg();
-  RCLCPP_INFO(getLogger(), "odom tracker updatd pose, frame: %s", pose.header.frame_id.c_str());
+  RCLCPP_INFO(getLogger(), "odom tracker updated pose, frame: %s", pose.header.frame_id.c_str());
   processNewPose(pose);
   RCLCPP_INFO(getLogger(), "odom_tracker update end");
 }

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/components/waypoints_navigator/cp_waypoints_navigator.cpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/components/waypoints_navigator/cp_waypoints_navigator.cpp
@@ -55,7 +55,7 @@ void CpWaypointNavigator::onGoalCancelled(
 {
   stopWaitingResult();
 
-  this->onNavigationRequestCancelled();
+  this->onNavigationRequestCancelled_();
 }
 
 void CpWaypointNavigator::onGoalAborted(
@@ -63,7 +63,7 @@ void CpWaypointNavigator::onGoalAborted(
 {
   stopWaitingResult();
 
-  this->onNavigationRequestAborted();
+  this->onNavigationRequestAborted_();
 }
 
 void CpWaypointNavigator::onGoalReached(
@@ -78,7 +78,7 @@ void CpWaypointNavigator::onGoalReached(
 
   this->notifyGoalReached();
 
-  onNavigationRequestSucceded();
+  onNavigationRequestSucceeded_();
 }
 
 void CpWaypointNavigatorBase::rewind(int /*count*/)
@@ -187,9 +187,9 @@ void CpWaypointNavigatorBase::loadWaypointsFromYamlParameter(
 
 void CpWaypointNavigator::stopWaitingResult()
 {
-  if (succeddedNav2ZClientConnection_.connected())
+  if (succeededNav2ZClientConnection_.connected())
   {
-    this->succeddedNav2ZClientConnection_.disconnect();
+    this->succeededNav2ZClientConnection_.disconnect();
     this->cancelledNav2ZClientConnection_.disconnect();
     this->abortedNav2ZClientConnection_.disconnect();
   }
@@ -283,9 +283,9 @@ CpWaypointNavigator::sendNextGoal(std::optional<NavigateNextWaypointOptions> opt
     }
 
     // SEND GOAL
-    // if (!succeddedNav2ZClientConnection_.connected())
+    // if (!succeededNav2ZClientConnection_.connected())
     // {
-    //   this->succeddedNav2ZClientConnection_ =
+    //   this->succeededNav2ZClientConnection_ =
     //     client_->onSucceeded(&WaypointNavigator::onGoalReached, this);
     //   this->cancelledNav2ZClientConnection_ =
     //     client_->onAborted(&WaypointNavigator::onGoalCancelled, this);
@@ -294,9 +294,9 @@ CpWaypointNavigator::sendNextGoal(std::optional<NavigateNextWaypointOptions> opt
     // }
 
     // Set up navigation result handling
-    if (!succeddedNav2ZClientConnection_.connected())
+    if (!succeededNav2ZClientConnection_.connected())
     {
-      succeddedNav2ZClientConnection_ =
+      succeededNav2ZClientConnection_ =
         nav2ActionInterface_->onNavigationSucceeded(&CpWaypointNavigator::onGoalReached, this);
       abortedNav2ZClientConnection_ =
         nav2ActionInterface_->onNavigationAborted(&CpWaypointNavigator::onGoalAborted, this);

--- a/smacc2_client_library/cl_nav2z/custom_planners/backward_global_planner/src/backward_global_planner/backward_global_planner.cpp
+++ b/smacc2_client_library/cl_nav2z/custom_planners/backward_global_planner/src/backward_global_planner/backward_global_planner.cpp
@@ -70,7 +70,7 @@ void BackwardGlobalPlanner::configure(
 
   // RCLCPP_INFO_NAMED(nh_->get_logger(), "Backwards", "BackwardGlobalPlanner initialize");
   costmap_ros_ = costmap_ros;
-  // RCLCPP_WARN_NAMED(nh_->get_logger(), "Backwards", "initializating global planner, costmap address: %ld",
+  // RCLCPP_WARN_NAMED(nh_->get_logger(), "Backwards", "initializing global planner, costmap address: %ld",
   // (long)costmap_ros);
 
   planPub_ = nh_->create_publisher<nav_msgs::msg::Path>("backward_planner/global_plan", 1);

--- a/smacc2_client_library/cl_nav2z/custom_planners/backward_local_planner/include/backward_local_planner/backward_local_planner.hpp
+++ b/smacc2_client_library/cl_nav2z/custom_planners/backward_local_planner/include/backward_local_planner/backward_local_planner.hpp
@@ -88,7 +88,7 @@ private:
   // returns true if found
   bool findInitialCarrotGoal(geometry_msgs::msg::PoseStamped & pose);
 
-  // returns true for a pure spining motion request
+  // returns true for a pure spinning motion request
   bool updateCarrotGoal(const geometry_msgs::msg::PoseStamped & pose);
 
   bool resamplePrecisePlan();

--- a/smacc2_client_library/cl_nav2z/custom_planners/backward_local_planner/src/backward_local_planner/backward_local_planner.cpp
+++ b/smacc2_client_library/cl_nav2z/custom_planners/backward_local_planner/src/backward_local_planner/backward_local_planner.cpp
@@ -234,7 +234,7 @@ void BackwardLocalPlanner::setSpeedLimit(
 {
   RCLCPP_WARN_STREAM(
     nh_->get_logger(),
-    "BackwardLocalPlanner::setSpeedLimit invoked. Ignored, funcionality not "
+    "BackwardLocalPlanner::setSpeedLimit invoked. Ignored, functionality not "
     "implemented.");
 }
 /**

--- a/smacc2_client_library/cl_nav2z/custom_planners/backward_local_planner/src/backward_local_planner/backward_local_planner.cpp
+++ b/smacc2_client_library/cl_nav2z/custom_planners/backward_local_planner/src/backward_local_planner/backward_local_planner.cpp
@@ -1157,8 +1157,8 @@ Eigen::Vector3f BackwardLocalPlanner::computeNewPositions(
   const Eigen::Vector3f & pos, const Eigen::Vector3f & vel, double dt)
 {
   Eigen::Vector3f new_pos = Eigen::Vector3f::Zero();
-  new_pos[0] = pos[0] + (vel[0] * cos(pos[2]) + vel[1] * cos(M_PI_2 + pos[2])) * dt;
-  new_pos[1] = pos[1] + (vel[0] * sin(pos[2]) + vel[1] * sin(M_PI_2 + pos[2])) * dt;
+  new_pos[0] = pos[0] + (static_cast<double>(vel[0]) * cos(pos[2]) + static_cast<double>(vel[1]) * cos(M_PI_2 + pos[2])) * dt;
+  new_pos[1] = pos[1] + (static_cast<double>(vel[0]) * sin(pos[2]) + static_cast<double>(vel[1]) * sin(M_PI_2 + pos[2])) * dt;
   new_pos[2] = pos[2] + vel[2] * dt;
   return new_pos;
 }

--- a/smacc2_client_library/cl_nav2z/custom_planners/backward_local_planner/src/backward_local_planner/backward_local_planner.cpp
+++ b/smacc2_client_library/cl_nav2z/custom_planners/backward_local_planner/src/backward_local_planner/backward_local_planner.cpp
@@ -1157,8 +1157,12 @@ Eigen::Vector3f BackwardLocalPlanner::computeNewPositions(
   const Eigen::Vector3f & pos, const Eigen::Vector3f & vel, double dt)
 {
   Eigen::Vector3f new_pos = Eigen::Vector3f::Zero();
-  new_pos[0] = pos[0] + (static_cast<double>(vel[0]) * cos(pos[2]) + static_cast<double>(vel[1]) * cos(M_PI_2 + pos[2])) * dt;
-  new_pos[1] = pos[1] + (static_cast<double>(vel[0]) * sin(pos[2]) + static_cast<double>(vel[1]) * sin(M_PI_2 + pos[2])) * dt;
+  new_pos[0] = pos[0] + (static_cast<double>(vel[0]) * cos(pos[2]) +
+                         static_cast<double>(vel[1]) * cos(M_PI_2 + pos[2])) *
+                          dt;
+  new_pos[1] = pos[1] + (static_cast<double>(vel[0]) * sin(pos[2]) +
+                         static_cast<double>(vel[1]) * sin(M_PI_2 + pos[2])) *
+                          dt;
   new_pos[2] = pos[2] + vel[2] * dt;
   return new_pos;
 }

--- a/smacc2_client_library/cl_nav2z/custom_planners/forward_local_planner/src/forward_local_planner/forward_local_planner.cpp
+++ b/smacc2_client_library/cl_nav2z/custom_planners/forward_local_planner/src/forward_local_planner/forward_local_planner.cpp
@@ -632,7 +632,7 @@ void ForwardLocalPlanner::setSpeedLimit(const double & /*speed_limit*/, const bo
 {
   RCLCPP_WARN_STREAM(
     nh_->get_logger(),
-    "ForwardLocalPlanner::setSpeedLimit invoked. Ignored, funcionality not "
+    "ForwardLocalPlanner::setSpeedLimit invoked. Ignored, functionality not "
     "implemented.");
 }
 

--- a/smacc2_client_library/cl_nav2z/custom_planners/forward_local_planner/src/forward_local_planner/forward_local_planner.cpp
+++ b/smacc2_client_library/cl_nav2z/custom_planners/forward_local_planner/src/forward_local_planner/forward_local_planner.cpp
@@ -214,8 +214,12 @@ Eigen::Vector3f ForwardLocalPlanner::computeNewPositions(
   const Eigen::Vector3f & pos, const Eigen::Vector3f & vel, double dt)
 {
   Eigen::Vector3f new_pos = Eigen::Vector3f::Zero();
-  new_pos[0] = pos[0] + (static_cast<double>(vel[0]) * cos(pos[2]) + static_cast<double>(vel[1]) * cos(M_PI_2 + pos[2])) * dt;
-  new_pos[1] = pos[1] + (static_cast<double>(vel[0]) * sin(pos[2]) + static_cast<double>(vel[1]) * sin(M_PI_2 + pos[2])) * dt;
+  new_pos[0] = pos[0] + (static_cast<double>(vel[0]) * cos(pos[2]) +
+                         static_cast<double>(vel[1]) * cos(M_PI_2 + pos[2])) *
+                          dt;
+  new_pos[1] = pos[1] + (static_cast<double>(vel[0]) * sin(pos[2]) +
+                         static_cast<double>(vel[1]) * sin(M_PI_2 + pos[2])) *
+                          dt;
   new_pos[2] = pos[2] + vel[2] * dt;
   return new_pos;
 }

--- a/smacc2_client_library/cl_nav2z/custom_planners/forward_local_planner/src/forward_local_planner/forward_local_planner.cpp
+++ b/smacc2_client_library/cl_nav2z/custom_planners/forward_local_planner/src/forward_local_planner/forward_local_planner.cpp
@@ -214,8 +214,8 @@ Eigen::Vector3f ForwardLocalPlanner::computeNewPositions(
   const Eigen::Vector3f & pos, const Eigen::Vector3f & vel, double dt)
 {
   Eigen::Vector3f new_pos = Eigen::Vector3f::Zero();
-  new_pos[0] = pos[0] + (vel[0] * cos(pos[2]) + vel[1] * cos(M_PI_2 + pos[2])) * dt;
-  new_pos[1] = pos[1] + (vel[0] * sin(pos[2]) + vel[1] * sin(M_PI_2 + pos[2])) * dt;
+  new_pos[0] = pos[0] + (static_cast<double>(vel[0]) * cos(pos[2]) + static_cast<double>(vel[1]) * cos(M_PI_2 + pos[2])) * dt;
+  new_pos[1] = pos[1] + (static_cast<double>(vel[0]) * sin(pos[2]) + static_cast<double>(vel[1]) * sin(M_PI_2 + pos[2])) * dt;
   new_pos[2] = pos[2] + vel[2] * dt;
   return new_pos;
 }

--- a/smacc2_client_library/cl_nav2z/custom_planners/nav2z_planners_common/src/nav2z_planners_common/common.cpp
+++ b/smacc2_client_library/cl_nav2z/custom_planners/nav2z_planners_common/src/nav2z_planners_common/common.cpp
@@ -39,8 +39,8 @@ geometry_msgs::msg::PoseStamped makePureSpinningSubPlan(
   std::vector<geometry_msgs::msg::PoseStamped> & plan, double radstep)
 {
   double startYaw = tf2::getYaw(start.pose.orientation);
-  // RCLCPP_INFO(getLogger(),"pure spining start yaw: %lf", startYaw);
-  // RCLCPP_INFO(getLogger(),"pure spining goal yaw: %lf", dstRads);
+  // RCLCPP_INFO(getLogger(),"pure spinning start yaw: %lf", startYaw);
+  // RCLCPP_INFO(getLogger(),"pure spinning goal yaw: %lf", dstRads);
   // RCLCPP_WARN_STREAM(getLogger(),"pure spinning start pose: " << start);
 
   double goalAngleOffset = angles::shortest_angular_distance(startYaw, dstRads);
@@ -49,12 +49,12 @@ geometry_msgs::msg::PoseStamped makePureSpinningSubPlan(
   if (goalAngleOffset >= 0)
   {
     // angle positive turn counterclockwise
-    // RCLCPP_INFO(getLogger(),"pure spining counterclockwise");
+    // RCLCPP_INFO(getLogger(),"pure spinning counterclockwise");
     for (double dangle = 0; dangle <= goalAngleOffset; dangle += radstep)
     {
       geometry_msgs::msg::PoseStamped p = start;
       double yaw = startYaw + dangle;
-      // RCLCPP_INFO(getLogger(),"pure spining counterclockwise, current path yaw: %lf, dangle: %lf,
+      // RCLCPP_INFO(getLogger(),"pure spinning counterclockwise, current path yaw: %lf, dangle: %lf,
       // angleoffset %lf, radstep %lf pathsize(%ld)", yaw, dangle, goalAngleOffset, radstep, plan.size());
       tf2::Quaternion q;
       q.setRPY(0, 0, yaw);
@@ -65,13 +65,13 @@ geometry_msgs::msg::PoseStamped makePureSpinningSubPlan(
   else
   {
     // angle positive turn clockwise
-    // RCLCPP_INFO(getLogger(),"pure spining clockwise");
+    // RCLCPP_INFO(getLogger(),"pure spinning clockwise");
     for (double dangle = 0; dangle >= goalAngleOffset; dangle -= radstep)
     {
       // RCLCPP_INFO(getLogger(),"dangle: %lf", dangle);
       geometry_msgs::msg::PoseStamped p = start;
       double yaw = startYaw + dangle;
-      // RCLCPP_INFO(getLogger(),"pure spining clockwise, yaw: %lf, dangle: %lf, angleoffset %lf radstep
+      // RCLCPP_INFO(getLogger(),"pure spinning clockwise, yaw: %lf, dangle: %lf, angleoffset %lf radstep
       // %lf", yaw, dangle, goalAngleOffset,radstep);
       tf2::Quaternion q;
       q.setRPY(0, 0, yaw);
@@ -80,7 +80,7 @@ geometry_msgs::msg::PoseStamped makePureSpinningSubPlan(
     }
   }
 
-  // RCLCPP_INFO(getLogger(),"pure spining end yaw: %lf", dstRads);
+  // RCLCPP_INFO(getLogger(),"pure spinning end yaw: %lf", dstRads);
   geometry_msgs::msg::PoseStamped end = start;
   tf2::Quaternion q;
   q.setRPY(0, 0, dstRads);

--- a/smacc2_client_library/cl_nav2z/custom_planners/pure_spinning_local_planner/src/pure_spinning_local_planner/pure_spinning_local_planner.cpp
+++ b/smacc2_client_library/cl_nav2z/custom_planners/pure_spinning_local_planner/src/pure_spinning_local_planner/pure_spinning_local_planner.cpp
@@ -183,7 +183,7 @@ void PureSpinningLocalPlanner::setSpeedLimit(
 {
   RCLCPP_WARN_STREAM(
     nh_->get_logger(),
-    "PureSpinningLocalPlanner::setSpeedLimit invoked. Ignored, funcionality not "
+    "PureSpinningLocalPlanner::setSpeedLimit invoked. Ignored, functionality not "
     "implemented.");
 }
 

--- a/smacc2_client_library/cl_nav2z/custom_planners/undo_path_global_planner/src/undo_path_global_planner/undo_path_global_planner.cpp
+++ b/smacc2_client_library/cl_nav2z/custom_planners/undo_path_global_planner/src/undo_path_global_planner/undo_path_global_planner.cpp
@@ -88,7 +88,7 @@ void UndoPathGlobalPlanner::configure(
   costmap_ros_ = costmap_ros;
   tf_ = tf;
   name_ = name;
-  // RCLCPP_WARN_NAMED(nh_->get_logger(), "Backwards", "initializating global planner, costmap address: %ld",
+  // RCLCPP_WARN_NAMED(nh_->get_logger(), "Backwards", "initializing global planner, costmap address: %ld",
   // (long)costmap_ros);
 
   rclcpp::SensorDataQoS qos;
@@ -271,7 +271,7 @@ void UndoPathGlobalPlanner::createDefaultUndoPathPlan(
       RCLCPP_WARN_STREAM(nh_->get_logger(), "[UndoPathGlobalPlanner] Warning possible bug");
     }
 
-    // ------- FULL FORWARD PASS TO FIND THE STARTING POIINT OF THE FORWARD MOTION ------
+    // ------- FULL FORWARD PASS TO FIND THE STARTING POINT OF THE FORWARD MOTION ------
     RCLCPP_INFO_STREAM(nh_->get_logger(), "[UndoPathGlobalPlanner] second pass loop");
     for (int i = mindistindex; i >= 0; i--)
     {

--- a/smacc2_performance_tools/performance_tests/sm_coretest_transition_speed_1/include/sm_coretest_transition_speed_1/states/st_state_1.hpp
+++ b/smacc2_performance_tools/performance_tests/sm_coretest_transition_speed_1/include/sm_coretest_transition_speed_1/states/st_state_1.hpp
@@ -23,7 +23,7 @@
 
 namespace sm_coretest_transition_speed_1
 {
-// SMACC2 clases
+// SMACC2 classes
 using smacc2::EvStateRequestFinish;
 using smacc2::Transition;
 

--- a/smacc2_performance_tools/performance_tests/sm_coretest_transition_speed_1/include/sm_coretest_transition_speed_1/states/st_state_2.hpp
+++ b/smacc2_performance_tools/performance_tests/sm_coretest_transition_speed_1/include/sm_coretest_transition_speed_1/states/st_state_2.hpp
@@ -26,7 +26,7 @@ using namespace std::chrono;
 
 namespace sm_coretest_transition_speed_1
 {
-// SMACC2 clases
+// SMACC2 classes
 using smacc2::EvStateRequestFinish;
 using smacc2::Transition;
 


### PR DESCRIPTION
  CodeQL Findings
  - signal_detector.cpp: fixed a dangling pointer where .c_str() was taken from a temporary std::string returned by demangleType(); the temporary was destroyed before the pointer was consumed by TRACETOOLS_TRACEPOINT (cpp/use-of-string-after-lifetime-ends)
  - forward_local_planner.cpp, backward_local_planner.cpp, cb_spiral_motion.cpp: cast float velocity operands to double before multiplication so intermediate arithmetic occurs at double precision rather than being widened after a potentially lossy float multiply (cpp/integer-multiplication-cast-to-long)

