### PR TITLE
Drop dependencies not required for building, running or tracing this package

### DIFF
--- a/smacc2/package.xml
+++ b/smacc2/package.xml
@@ -15,14 +15,11 @@
 
   <build_depend>libboost-thread-dev</build_depend>
 
-  <depend>liblttng-ust-dev</depend>
   <depend>rcl</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>smacc2_msgs</depend>
   <depend>tracetools</depend>
-  <depend>tracetools_trace</depend>
-  <depend>tracetools_launch</depend>
 
   <exec_depend>libboost-thread</exec_depend>
 


### PR DESCRIPTION
I ran into issues where I did not have these dependencies (yet).

But they are never `find_package`-ed. So they should not be listed as `<depend>` here.