### PR TITLE
Fix boost statechart dependency

### DIFF
--- a/smacc2/package.xml
+++ b/smacc2/package.xml
@@ -13,6 +13,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>libboost-dev</build_depend>  <!-- boost/statechart -->
   <build_depend>libboost-thread-dev</build_depend>
 
   <depend>liblttng-ust-dev</depend>

--- a/smacc2_client_library/cl_ros2_timer/CMakeLists.txt
+++ b/smacc2_client_library/cl_ros2_timer/CMakeLists.txt
@@ -24,7 +24,7 @@ include_directories(
 add_library(${PROJECT_NAME}
   src/cl_ros2_timer.cpp
 )
-target_link_libraries(${PROJECT_NAME} SHARED ${Boost_LIBRARIES} smacc2)
+target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} smacc2)
 ament_target_dependencies(${PROJECT_NAME} smacc2)
 
 ament_export_include_directories(include)


### PR DESCRIPTION
In an isolated environment I got:

```
 │ │ $PREFIX/include/smacc2/common.hpp:24:10: fatal error: boost/statechart/asynchronous_state_machine.hpp: No such file or directory
 │ │    24 | #include <boost/statechart/asynchronous_state_machine.hpp>
 │ │       |          ^~~~~~~~~~~~~~~~~
```

Since it's header only, boost statechart is part of `libboost-dev`.