### PR TITLE
Add explicit dependencies for Nav2 planner plugins for jazzy

### DIFF
--- a/smacc2_client_library/cl_nav2z/custom_planners/backward_global_planner/CMakeLists.txt
+++ b/smacc2_client_library/cl_nav2z/custom_planners/backward_global_planner/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(pluginlib)
 find_package(forward_global_planner)
 find_package(angles)
 find_package(nav_2d_utils)
+find_package(nav2z_planners_common)
 
 set(dependencies
   nav2_core
@@ -34,6 +35,7 @@ set(dependencies
   forward_global_planner
   angles
   nav_2d_utils
+  nav2z_planners_common
 )
 
 include_directories(include)

--- a/smacc2_client_library/cl_nav2z/custom_planners/backward_global_planner/package.xml
+++ b/smacc2_client_library/cl_nav2z/custom_planners/backward_global_planner/package.xml
@@ -21,6 +21,7 @@
   <depend>forward_global_planner</depend>
   <depend>visualization_msgs</depend>
   <depend>nav_2d_utils</depend>
+  <depend>nav2z_planners_common</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/smacc2_client_library/cl_nav2z/custom_planners/backward_local_planner/CMakeLists.txt
+++ b/smacc2_client_library/cl_nav2z/custom_planners/backward_local_planner/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(geometry_msgs)
 find_package(tf2)
 find_package(nav2z_planners_common)
 find_package(pluginlib)
+find_package(angles)
 find_package(nav_2d_utils)
 
 set(dependencies
@@ -31,6 +32,7 @@ set(dependencies
   tf2
   nav2z_planners_common
   pluginlib
+  angles
   nav_2d_utils
 )
 

--- a/smacc2_client_library/cl_nav2z/custom_planners/backward_local_planner/package.xml
+++ b/smacc2_client_library/cl_nav2z/custom_planners/backward_local_planner/package.xml
@@ -11,6 +11,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>angles</depend>
   <depend>nav2_costmap_2d</depend>
   <depend>geometry_msgs</depend>
   <depend>nav2z_planners_common</depend>

--- a/smacc2_client_library/cl_nav2z/custom_planners/forward_global_planner/CMakeLists.txt
+++ b/smacc2_client_library/cl_nav2z/custom_planners/forward_global_planner/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(geometry_msgs)
 find_package(tf2)
 find_package(nav2z_planners_common)
 find_package(pluginlib)
+find_package(angles)
 find_package(nav_2d_utils)
 
 set(dependencies
@@ -30,6 +31,7 @@ set(dependencies
   tf2
   nav2z_planners_common
   pluginlib
+  angles
   nav_2d_utils
 )
 

--- a/smacc2_client_library/cl_nav2z/custom_planners/forward_global_planner/package.xml
+++ b/smacc2_client_library/cl_nav2z/custom_planners/forward_global_planner/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>angles</depend>
   <depend>geometry_msgs</depend>
   <depend>nav2z_planners_common</depend>
   <depend>nav_2d_utils</depend>

--- a/smacc2_client_library/cl_nav2z/custom_planners/forward_local_planner/CMakeLists.txt
+++ b/smacc2_client_library/cl_nav2z/custom_planners/forward_local_planner/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(geometry_msgs)
 find_package(tf2)
 find_package(nav2z_planners_common)
 find_package(pluginlib)
+find_package(angles)
 find_package(nav_2d_utils)
 
 set(dependencies
@@ -30,6 +31,7 @@ set(dependencies
   tf2
   nav2z_planners_common
   pluginlib
+  angles
   nav_2d_utils
 )
 

--- a/smacc2_client_library/cl_nav2z/custom_planners/forward_local_planner/package.xml
+++ b/smacc2_client_library/cl_nav2z/custom_planners/forward_local_planner/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>angles</depend>
   <depend>geometry_msgs</depend>
   <depend>nav2z_planners_common</depend>
   <depend>nav_2d_utils</depend>

--- a/smacc2_client_library/cl_nav2z/custom_planners/pure_spinning_local_planner/CMakeLists.txt
+++ b/smacc2_client_library/cl_nav2z/custom_planners/pure_spinning_local_planner/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(tf2_geometry_msgs)
 find_package(tf2_ros)
 find_package(nav2z_planners_common)
 find_package(pluginlib)
+find_package(angles)
 find_package(nav_2d_utils)
 
 set(dependencies
@@ -32,6 +33,7 @@ set(dependencies
   tf2
   nav2z_planners_common
   pluginlib
+  angles
   nav_2d_utils
 )
 

--- a/smacc2_client_library/cl_nav2z/custom_planners/pure_spinning_local_planner/package.xml
+++ b/smacc2_client_library/cl_nav2z/custom_planners/pure_spinning_local_planner/package.xml
@@ -12,6 +12,7 @@
 
   <build_depend>pluginlib</build_depend>
 
+  <depend>angles</depend>
   <depend>geometry_msgs</depend>
   <depend>nav2z_planners_common</depend>
   <depend>nav_2d_utils</depend>

--- a/smacc2_client_library/cl_nav2z/custom_planners/undo_path_global_planner/CMakeLists.txt
+++ b/smacc2_client_library/cl_nav2z/custom_planners/undo_path_global_planner/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(nav2_costmap_2d)
 find_package(tf2)
 find_package(tf2_geometry_msgs)
 find_package(pluginlib)
+find_package(angles)
 find_package(nav2z_planners_common)
 
 set(dependencies
@@ -32,6 +33,7 @@ set(dependencies
   tf2
   tf2_geometry_msgs
   pluginlib
+  angles
   nav_2d_utils
   nav2z_planners_common
 )

--- a/smacc2_client_library/cl_nav2z/custom_planners/undo_path_global_planner/package.xml
+++ b/smacc2_client_library/cl_nav2z/custom_planners/undo_path_global_planner/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>angles</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_2d_utils</depend>
   <depend>nav_msgs</depend>


### PR DESCRIPTION
## Summary

This PR follows up on the confirmed `backward_local_planner` report. The same
direct-dependency issue was found in five related planner packages:

| Package | Dependency | Directly used API |
| --- | --- | --- |
| `backward_global_planner` | `nav2z_planners_common` | `cl_nav2z::makePureSpinningSubPlan()`, `cl_nav2z::makePureStraightSubPlan()` |
| `backward_local_planner` | `angles` | `angles::shortest_angular_distance()` |
| `forward_global_planner` | `angles` | `angles::normalize_angle()` |
| `forward_local_planner` | `angles` | `angles::shortest_angular_distance()` |
| `pure_spinning_local_planner` | `angles` | `angles::shortest_angular_distance()` |
| `undo_path_global_planner` | `angles` | `angles::shortest_angular_distance()` |

## Changes

For each package, add the dependency to `package.xml`, `find_package()`, and
the existing CMake `dependencies` list. This removes reliance on transitive
dependency paths.