### PR TITLE
Fix cl_ros2_timer cmake shared-library link failure on bare smacc2 reference

### DIFF
--- a/smacc2_client_library/cl_ros2_timer/CMakeLists.txt
+++ b/smacc2_client_library/cl_ros2_timer/CMakeLists.txt
@@ -24,7 +24,7 @@ include_directories(
 add_library(${PROJECT_NAME}
   src/cl_ros2_timer.cpp
 )
-target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} smacc2)
+target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES})
 ament_target_dependencies(${PROJECT_NAME} smacc2)
 
 ament_export_include_directories(include)


### PR DESCRIPTION
ament_target_dependencies() already links smacc2 via its resolved absolute path. The bare 'smacc2' in target_link_libraries() isn't a real CMake target, so it resolves to an unlinkable -lsmacc2 when built as a shared library (confirmed with -DBUILD_SHARED_LIBS=ON). Masked locally by this package's default static-lib build, and left unaddressed by #768/#772, which only fixed the invalid SHARED keyword on the same line.