### PR TITLE
Addition of cb_assisted_teleop and minor refactoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,16 +115,16 @@ SmaccSignal is a communication mechanism (template wrapper around boost::signals
   ### Example usage in Clients:
   - smacc2_client_library/cl_lifecycle_node/include/cl_lifecycle_node/cl_lifecycle_node.hpp
   - smacc2_client_library/cl_ros2_timer/include/cl_ros2_timer/cl_ros2_timer.hpp
-  - smacc2_client_library/moveit2z_client/include/moveit2z_client/cl_moveit2z.hpp
-  - smacc2_client_library/nav2z_client/nav2z_client/include/nav2z_client/nav2z_client.hpp
-  - smacc2_client_library/http_client/include/http_client/cl_http_client.hpp
+  - smacc2_client_library/cl_moveit2z/include/cl_moveit2z/cl_moveit2z.hpp
+  - smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/cl_nav2z.hpp
+  - smacc2_client_library/cl_http/include/cl_http/cl_http.hpp
   - smacc2_client_library/cl_keyboard/include/cl_keyboard/cl_keyboard.hpp
 
   ### Example usage in Client Behaviors:
   - smacc2_client_library/cl_ros2_timer/include/cl_ros2_timer/client_behaviors/cb_timer_countdown_once.hpp
 
   ### Example usage in Components:
-  - smacc2_client_library/nav2z_client/nav2z_client/include/nav2z_client/components/waypoints_navigator/cp_waypoints_navigator.hpp
+  - smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/components/waypoints_navigator/cp_waypoints_navigator.hpp
 
   ### Boost Signals2 Documentation
   https://www.boost.org/doc/libs/1_89_0/doc/html/signals2.html

--- a/smacc2/include/smacc2/client_behavior_bases/cb_action_client_behavior_base.hpp
+++ b/smacc2/include/smacc2/client_behavior_bases/cb_action_client_behavior_base.hpp
@@ -73,9 +73,9 @@ public:
 
     if (!resultConnectionsInitialized_ && actionClient_ != nullptr)
     {
-      actionClient_->onSucceeded(&CbActionClientBehaviorBase::onActionSuccess, this);
-      actionClient_->onAborted(&CbActionClientBehaviorBase::onActionAbort, this);
-      actionClient_->onCancelled(&CbActionClientBehaviorBase::onActionAbort, this);
+      actionClient_->onSucceeded(&CbActionClientBehaviorBase::dispatchActionSuccess, this);
+      actionClient_->onAborted(&CbActionClientBehaviorBase::dispatchActionAbort, this);
+      actionClient_->onCancelled(&CbActionClientBehaviorBase::dispatchActionAbort, this);
       actionClient_->onFeedback(&CbActionClientBehaviorBase::onActionFeedback, this);
       resultConnectionsInitialized_ = true;
     }
@@ -162,7 +162,6 @@ protected:
   // derived classes may override to customize result handling.
   virtual void onActionSuccess(const WrappedResult & result)
   {
-    goalInFlight_ = false;
     actionResult_ = result.code;
     RCLCPP_INFO(getLogger(), "[%s] Action succeeded, propagating success event", getName().c_str());
     this->postSuccessEvent();
@@ -170,7 +169,6 @@ protected:
 
   virtual void onActionAbort(const WrappedResult & result)
   {
-    goalInFlight_ = false;
     actionResult_ = result.code;
     RCLCPP_INFO(getLogger(), "[%s] Action failed, propagating failure event", getName().c_str());
     this->postFailureEvent();
@@ -194,6 +192,21 @@ protected:
   std::chrono::milliseconds goalResponseTimeout_ = std::chrono::milliseconds(10000);
 
 private:
+  // trampolines wired to the component signals: clear the in-flight flag
+  // regardless of what a derived handler override does, then dispatch to the
+  // overridable virtuals
+  void dispatchActionSuccess(const WrappedResult & result)
+  {
+    goalInFlight_ = false;
+    this->onActionSuccess(result);
+  }
+
+  void dispatchActionAbort(const WrappedResult & result)
+  {
+    goalInFlight_ = false;
+    this->onActionAbort(result);
+  }
+
   bool resultConnectionsInitialized_ = false;
   std::atomic<bool> goalInFlight_{false};
 };

--- a/smacc2/include/smacc2/client_behavior_bases/cb_action_client_behavior_base.hpp
+++ b/smacc2/include/smacc2/client_behavior_bases/cb_action_client_behavior_base.hpp
@@ -60,7 +60,16 @@ public:
   template <typename TOrthogonal, typename TSourceObject>
   void onStateOrthogonalAllocation()
   {
-    this->requiresComponent(actionClient_, ComponentRequirement::HARD);
+    if (actionClientName_.empty())
+    {
+      this->requiresComponent(actionClient_, ComponentRequirement::HARD);
+    }
+    else
+    {
+      // target a specific named instance when the client holds several
+      // CpActionClient components of the same action type
+      this->requiresComponent(actionClientName_, actionClient_, ComponentRequirement::HARD);
+    }
 
     if (!resultConnectionsInitialized_ && actionClient_ != nullptr)
     {
@@ -170,7 +179,14 @@ protected:
   // optional: override to consume action feedback (distance traveled etc.)
   virtual void onActionFeedback(const Feedback & /*feedback*/) {}
 
+  // set from the derived constructor to bind to a named CpActionClient
+  // instance; empty binds the first of matching type. Must be set before
+  // onStateOrthogonalAllocation runs (i.e. NOT in runtimeConfigure, which
+  // executes after allocation)
+  void setActionClientName(std::string name) { actionClientName_ = std::move(name); }
+
   ActionClientComponent * actionClient_ = nullptr;
+  std::string actionClientName_;
 
   rclcpp_action::ResultCode actionResult_ = rclcpp_action::ResultCode::UNKNOWN;
 

--- a/smacc2/include/smacc2/client_behavior_bases/cb_action_client_behavior_base.hpp
+++ b/smacc2/include/smacc2/client_behavior_bases/cb_action_client_behavior_base.hpp
@@ -76,7 +76,7 @@ public:
       actionClient_->onSucceeded(&CbActionClientBehaviorBase::dispatchActionSuccess, this);
       actionClient_->onAborted(&CbActionClientBehaviorBase::dispatchActionAbort, this);
       actionClient_->onCancelled(&CbActionClientBehaviorBase::dispatchActionAbort, this);
-      actionClient_->onFeedback(&CbActionClientBehaviorBase::onActionFeedback, this);
+      actionClient_->onFeedback(&CbActionClientBehaviorBase::dispatchActionFeedback, this);
       resultConnectionsInitialized_ = true;
     }
 
@@ -119,12 +119,25 @@ protected:
       return false;
     }
 
+    goalActivitySeen_ = false;
     auto goalHandleFuture = actionClient_->sendGoal(goal);
 
     // wait for goal acceptance in short slices so a state exit is honored
     auto deadline = std::chrono::steady_clock::now() + goalResponseTimeout_;
     while (!this->isShutdownRequested() && std::chrono::steady_clock::now() < deadline)
     {
+      // Feedback or a result arriving proves the goal was accepted even if
+      // the goal-response future hasn't been serviced yet: under spin_some, a
+      // high-rate feedback stream (NavigateToPose feeds back continuously
+      // from acceptance) can starve the action client's response processing
+      // for the whole execution. Rejected goals produce no feedback, so their
+      // response resolves the future promptly.
+      if (goalActivitySeen_)
+      {
+        goalInFlight_ = true;
+        return true;
+      }
+
       if (goalHandleFuture.wait_for(std::chrono::milliseconds(50)) == std::future_status::ready)
       {
         if (goalHandleFuture.get() != nullptr)
@@ -141,12 +154,20 @@ protected:
 
     if (!this->isShutdownRequested())
     {
-      RCLCPP_ERROR(
-        getLogger(), "[%s] Timed out waiting for the action server goal response",
-        getName().c_str());
-      this->postFailureEvent();
+      // No response, no feedback, no result within the window: ambiguous, and
+      // observed only under executor starvation with an accepted goal - a
+      // genuine rejection resolves the future in milliseconds. Assume the
+      // goal is running and let the result signals finish the behavior
+      // (fire-and-forget, the pre-template behavior), rather than failing a
+      // healthy mission.
+      RCLCPP_WARN(
+        getLogger(),
+        "[%s] No goal response from the action server after %ld ms; assuming the goal was "
+        "accepted (a rejection responds promptly) - result signals will finish this behavior",
+        getName().c_str(), static_cast<long>(goalResponseTimeout_.count()));
+      goalInFlight_ = true;
     }
-    return false;
+    return true;
   }
 
   void cancelGoal()
@@ -197,18 +218,27 @@ private:
   // overridable virtuals
   void dispatchActionSuccess(const WrappedResult & result)
   {
+    goalActivitySeen_ = true;
     goalInFlight_ = false;
     this->onActionSuccess(result);
   }
 
   void dispatchActionAbort(const WrappedResult & result)
   {
+    goalActivitySeen_ = true;
     goalInFlight_ = false;
     this->onActionAbort(result);
   }
 
+  void dispatchActionFeedback(const Feedback & feedback)
+  {
+    goalActivitySeen_ = true;
+    this->onActionFeedback(feedback);
+  }
+
   bool resultConnectionsInitialized_ = false;
   std::atomic<bool> goalInFlight_{false};
+  std::atomic<bool> goalActivitySeen_{false};
 };
 
 }  // namespace client_behavior_bases

--- a/smacc2/include/smacc2/impl/smacc_client_behavior_impl.hpp
+++ b/smacc2/include/smacc2/impl/smacc_client_behavior_impl.hpp
@@ -86,6 +86,23 @@ void ISmaccClientBehavior::requiresComponent(
   }
 }
 
+template <typename SmaccComponentType>
+void ISmaccClientBehavior::requiresComponent(
+  std::string name, SmaccComponentType *& storage, ComponentRequirement requirementType)
+{
+  if (stateMachine_ == nullptr)
+  {
+    RCLCPP_ERROR(
+      getLogger(),
+      "Cannot use the requiresComponent functionality before assigning the client behavior to an "
+      "orthogonal. Try using the OnEntry method to capture required components.");
+  }
+  else
+  {
+    stateMachine_->requiresComponent(name, storage, requirementType);
+  }
+}
+
 template <typename TOrthogonal, typename TSourceObject>
 void ISmaccClientBehavior::onStateOrthogonalAllocation()
 {

--- a/smacc2/include/smacc2/impl/smacc_state_machine_impl.hpp
+++ b/smacc2/include/smacc2/impl/smacc_state_machine_impl.hpp
@@ -143,6 +143,36 @@ void ISmaccStateMachine::requiresComponent(
     throw std::runtime_error("component is required but it was not found in any orthogonal");
 }
 //-------------------------------------------------------------------------------------------------------
+template <typename SmaccComponentType>
+void ISmaccStateMachine::requiresComponent(
+  std::string name, SmaccComponentType *& storage, ComponentRequirement requirementType)
+{
+  bool throwsException = requirementType == ComponentRequirement::HARD;
+  RCLCPP_DEBUG(
+    getLogger(), "component %s (named '%s') is required",
+    demangleSymbol(typeid(SmaccComponentType).name()).c_str(), name.c_str());
+  std::lock_guard<std::recursive_mutex> lock(m_mutex_);
+
+  for (auto ortho : this->orthogonals_)
+  {
+    for (auto & client : ortho.second->clients_)
+    {
+      storage = client->getComponent<SmaccComponentType>(name);
+      if (storage != nullptr)
+      {
+        return;
+      }
+    }
+  }
+
+  RCLCPP_WARN(
+    getLogger(), "component %s (named '%s') is required but it was not found in any orthogonal",
+    demangleSymbol(typeid(SmaccComponentType).name()).c_str(), name.c_str());
+
+  if (throwsException)
+    throw std::runtime_error("named component is required but it was not found in any orthogonal");
+}
+//-------------------------------------------------------------------------------------------------------
 template <typename EventType>
 void ISmaccStateMachine::postEvent(EventType * ev, EventLifeTime evlifetime)
 {

--- a/smacc2/include/smacc2/smacc_client_behavior_base.hpp
+++ b/smacc2/include/smacc2/smacc_client_behavior_base.hpp
@@ -46,6 +46,14 @@ public:
     SmaccComponentType *& storage,
     ComponentRequirement requirementType = ComponentRequirement::SOFT);
 
+  // named variant: resolves the component instance created with this name
+  // (e.g. createComponent<CpActionClient<Spin>>("/spin")), for clients holding
+  // several components of the same type
+  template <typename SmaccComponentType>
+  void requiresComponent(
+    std::string name, SmaccComponentType *& storage,
+    ComponentRequirement requirementType = ComponentRequirement::SOFT);
+
   virtual void onEntry() {}
 
   virtual void onExit() {}

--- a/smacc2/include/smacc2/smacc_state_machine.hpp
+++ b/smacc2/include/smacc2/smacc_state_machine.hpp
@@ -93,6 +93,10 @@ public:
   template <typename SmaccComponentType>
   void requiresComponent(SmaccComponentType *& storage, ComponentRequirement requirementType);
 
+  template <typename SmaccComponentType>
+  void requiresComponent(
+    std::string name, SmaccComponentType *& storage, ComponentRequirement requirementType);
+
   template <typename EventType>
   void postEvent(EventType * ev, EventLifeTime evlifetime = EventLifeTime::ABSOLUTE);
 

--- a/smacc2_client_library/CLAUDE.md
+++ b/smacc2_client_library/CLAUDE.md
@@ -68,9 +68,9 @@ The SMACC2 Client Library provides modular, reusable clients for robot behaviors
 | Client | Purpose | Core Components |
 |--------|---------|-----------------|
 | `cl_nav2z` | Navigation with Nav2 | CpActionClient, CpNav2ActionInterface |
-| `cl_moveit2z` | Manipulation with MoveIt2 | CpMoveItInterface |
+| `cl_moveit2z` | Manipulation with MoveIt2 | CpMoveGroupInterface |
 | `cl_keyboard` | Keyboard input handling | CpTopicSubscriber, CpKeyboardListener1 |
-| `cl_ros2_timer` | Timer-based behaviors | CbTimerCountdownOnce, CbTimerCountdownLoop |
+| `cl_ros2_timer` | Timer-based behaviors | CpRos2Timer (core) |
 | `cl_http` | HTTP requests | CpHttpConnectionManager, CpHttpRequestExecutor |
 | `cl_lifecycle_node` | ROS2 lifecycle management | CpLifecycleEventMonitor |
 | `cl_generic_sensor` | Generic sensor input | CpTopicSubscriber, CpMessageTimeout |
@@ -178,11 +178,11 @@ Timer component for periodic or one-shot execution.
 
 | Client | Purpose | Main Header |
 |--------|---------|-------------|
-| cl_nav2z | Navigation with Nav2 | [cl_nav2z.hpp](https://github.com/robosoft-ai/SMACC2/blob/jazzy/smacc2_client_library/cl_nav2z/include/cl_nav2z/cl_nav2z.hpp) / `src/SMACC2/smacc2_client_library/cl_nav2z/include/cl_nav2z/cl_nav2z.hpp` |
+| cl_nav2z | Navigation with Nav2 | [cl_nav2z.hpp](https://github.com/robosoft-ai/SMACC2/blob/jazzy/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/cl_nav2z.hpp) / `src/SMACC2/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/cl_nav2z.hpp` |
 | cl_moveit2z | Manipulation with MoveIt2 | [cl_moveit2z.hpp](https://github.com/robosoft-ai/SMACC2/blob/jazzy/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/cl_moveit2z.hpp) / `src/SMACC2/smacc2_client_library/cl_moveit2z/include/cl_moveit2z/cl_moveit2z.hpp` |
 | cl_keyboard | Keyboard input handling | [cl_keyboard.hpp](https://github.com/robosoft-ai/SMACC2/blob/jazzy/smacc2_client_library/cl_keyboard/include/cl_keyboard/cl_keyboard.hpp) / `src/SMACC2/smacc2_client_library/cl_keyboard/include/cl_keyboard/cl_keyboard.hpp` |
-| cl_ros2_timer | Timer-based behaviors | [cl_ros_timer.hpp](https://github.com/robosoft-ai/SMACC2/blob/jazzy/smacc2_client_library/cl_ros2_timer/include/cl_ros2_timer/cl_ros_timer.hpp) / `src/SMACC2/smacc2_client_library/cl_ros2_timer/include/cl_ros2_timer/cl_ros_timer.hpp` |
-| cl_http | HTTP requests | [cl_http_client.hpp](https://github.com/robosoft-ai/SMACC2/blob/jazzy/smacc2_client_library/cl_http/include/cl_http/cl_http_client.hpp) / `src/SMACC2/smacc2_client_library/cl_http/include/cl_http/cl_http_client.hpp` |
+| cl_ros2_timer | Timer-based behaviors | [cl_ros2_timer.hpp](https://github.com/robosoft-ai/SMACC2/blob/jazzy/smacc2_client_library/cl_ros2_timer/include/cl_ros2_timer/cl_ros2_timer.hpp) / `src/SMACC2/smacc2_client_library/cl_ros2_timer/include/cl_ros2_timer/cl_ros2_timer.hpp` |
+| cl_http | HTTP requests | [cl_http.hpp](https://github.com/robosoft-ai/SMACC2/blob/jazzy/smacc2_client_library/cl_http/include/cl_http/cl_http.hpp) / `src/SMACC2/smacc2_client_library/cl_http/include/cl_http/cl_http.hpp` |
 | cl_lifecycle_node | ROS2 lifecycle management | [cl_lifecycle_node.hpp](https://github.com/robosoft-ai/SMACC2/blob/jazzy/smacc2_client_library/cl_lifecycle_node/include/cl_lifecycle_node/cl_lifecycle_node.hpp) / `src/SMACC2/smacc2_client_library/cl_lifecycle_node/include/cl_lifecycle_node/cl_lifecycle_node.hpp` |
 | cl_mission_tracker | Mission state management | [cl_mission_tracker.hpp](https://github.com/robosoft-ai/SMACC2/blob/jazzy/smacc2_client_library/cl_mission_tracker/include/cl_mission_tracker/cl_mission_tracker.hpp) / `src/SMACC2/smacc2_client_library/cl_mission_tracker/include/cl_mission_tracker/cl_mission_tracker.hpp` |
 | cl_isaac_apriltag | AprilTag detection | [cl_isaac_apriltag.hpp](https://github.com/robosoft-ai/SMACC2/blob/jazzy/smacc2_client_library/cl_isaac_apriltag/include/cl_isaac_apriltag/cl_isaac_apriltag.hpp) / `src/SMACC2/smacc2_client_library/cl_isaac_apriltag/include/cl_isaac_apriltag/cl_isaac_apriltag.hpp` |

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/CMakeLists.txt
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/CMakeLists.txt
@@ -57,6 +57,9 @@ add_library(${PROJECT_NAME} SHARED
   src/${PROJECT_NAME}/client_behaviors/cb_spin.cpp
   src/${PROJECT_NAME}/client_behaviors/cb_back_up.cpp
   src/${PROJECT_NAME}/client_behaviors/cb_drive_on_heading.cpp
+  src/${PROJECT_NAME}/client_behaviors/cb_assisted_teleop.cpp
+  src/${PROJECT_NAME}/client_behaviors/cb_dock_robot.cpp
+  src/${PROJECT_NAME}/client_behaviors/cb_undock_robot.cpp
   src/${PROJECT_NAME}/client_behaviors/cb_rotate_look_at.cpp
   src/${PROJECT_NAME}/client_behaviors/cb_navigate_backward.cpp
   src/${PROJECT_NAME}/client_behaviors/cb_navigate_forward.cpp

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors.hpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors.hpp
@@ -19,13 +19,16 @@
 #include <cl_nav2z/client_behaviors/cb_rotate.hpp>
 #include <cl_nav2z/client_behaviors/cb_rotate_look_at.hpp>
 
+#include <cl_nav2z/client_behaviors/cb_assisted_teleop.hpp>
 #include <cl_nav2z/client_behaviors/cb_back_up.hpp>
+#include <cl_nav2z/client_behaviors/cb_dock_robot.hpp>
 #include <cl_nav2z/client_behaviors/cb_drive_on_heading.hpp>
 #include <cl_nav2z/client_behaviors/cb_navigate_backwards.hpp>
 #include <cl_nav2z/client_behaviors/cb_navigate_forward.hpp>
 #include <cl_nav2z/client_behaviors/cb_navigate_global_position.hpp>
 #include <cl_nav2z/client_behaviors/cb_retry_behavior.hpp>
 #include <cl_nav2z/client_behaviors/cb_spin.hpp>
+#include <cl_nav2z/client_behaviors/cb_undock_robot.hpp>
 #include <cl_nav2z/client_behaviors/cb_undo_path_backwards.hpp>
 
 // nav2 synchronization behaviors

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors.hpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors.hpp
@@ -28,8 +28,8 @@
 #include <cl_nav2z/client_behaviors/cb_navigate_global_position.hpp>
 #include <cl_nav2z/client_behaviors/cb_retry_behavior.hpp>
 #include <cl_nav2z/client_behaviors/cb_spin.hpp>
-#include <cl_nav2z/client_behaviors/cb_undock_robot.hpp>
 #include <cl_nav2z/client_behaviors/cb_undo_path_backwards.hpp>
+#include <cl_nav2z/client_behaviors/cb_undock_robot.hpp>
 
 // nav2 synchronization behaviors
 #include <cl_nav2z/client_behaviors/cb_wait_nav2_nodes.hpp>

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors/cb_assisted_teleop.hpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors/cb_assisted_teleop.hpp
@@ -25,9 +25,8 @@ namespace cl_nav2z
 // through the local costmap and scaled/zeroed before a collision. The action
 // runs for the whole time allowance (success on expiry); leaving the state
 // early cancels it through the behavior base.
-class CbAssistedTeleop
-: public smacc2::client_behavior_bases::CbActionClientBehaviorBase<
-    nav2_msgs::action::AssistedTeleop>
+class CbAssistedTeleop : public smacc2::client_behavior_bases::CbActionClientBehaviorBase<
+                           nav2_msgs::action::AssistedTeleop>
 {
 public:
   explicit CbAssistedTeleop(std::chrono::seconds timeAllowance = std::chrono::seconds(30));

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors/cb_assisted_teleop.hpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors/cb_assisted_teleop.hpp
@@ -1,0 +1,41 @@
+// Copyright 2026 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <nav2_msgs/action/assisted_teleop.hpp>
+#include <smacc2/client_behavior_bases/cb_action_client_behavior_base.hpp>
+
+namespace cl_nav2z
+{
+
+// Collision-guarded teleoperation via the Nav2 behavior server's
+// AssistedTeleop action: incoming teleop velocity commands are projected
+// through the local costmap and scaled/zeroed before a collision. The action
+// runs for the whole time allowance (success on expiry); leaving the state
+// early cancels it through the behavior base.
+class CbAssistedTeleop
+: public smacc2::client_behavior_bases::CbActionClientBehaviorBase<
+    nav2_msgs::action::AssistedTeleop>
+{
+public:
+  explicit CbAssistedTeleop(std::chrono::seconds timeAllowance = std::chrono::seconds(30));
+
+  void onEntry() override;
+
+private:
+  std::chrono::seconds timeAllowance_;
+};
+
+}  // namespace cl_nav2z

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors/cb_dock_robot.hpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors/cb_dock_robot.hpp
@@ -1,0 +1,50 @@
+// Copyright 2026 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <nav2_msgs/action/dock_robot.hpp>
+#include <smacc2/client_behavior_bases/cb_action_client_behavior_base.hpp>
+
+namespace cl_nav2z
+{
+
+// Dock the robot via the Nav2 docking server (opennav_docking): navigate to
+// the dock's staging pose, detect the dock, drive in, and confirm charging.
+// Requires the docking server running with a dock database (dock-id form) or
+// a detectable dock at the given pose (dock-pose form).
+class CbDockRobot
+: public smacc2::client_behavior_bases::CbActionClientBehaviorBase<nav2_msgs::action::DockRobot>
+{
+public:
+  // dock at a named dock from the server's dock database
+  explicit CbDockRobot(std::string dockId);
+
+  // dock at an explicit pose; dockType selects the dock plugin when the
+  // server has several configured
+  CbDockRobot(geometry_msgs::msg::PoseStamped dockPose, std::string dockType = "");
+
+  void onEntry() override;
+
+private:
+  bool useDockId_;
+  std::string dockId_;
+  geometry_msgs::msg::PoseStamped dockPose_;
+  std::string dockType_;
+};
+
+}  // namespace cl_nav2z

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors/cb_nav2z_client_behavior_base.hpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors/cb_nav2z_client_behavior_base.hpp
@@ -36,8 +36,8 @@ using namespace smacc2;
 // nav-domain component (CpNav2ActionInterface, which posts the machine-scoped
 // EvAction* navigation events) and keeps the historical nav-named result
 // virtuals for existing overriders.
-class CbNav2ZClientBehaviorBase
-: public smacc2::client_behavior_bases::CbActionClientBehaviorBase<nav2_msgs::action::NavigateToPose>
+class CbNav2ZClientBehaviorBase : public smacc2::client_behavior_bases::CbActionClientBehaviorBase<
+                                    nav2_msgs::action::NavigateToPose>
 {
   using CbActionBase =
     smacc2::client_behavior_bases::CbActionClientBehaviorBase<nav2_msgs::action::NavigateToPose>;

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors/cb_nav2z_client_behavior_base.hpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors/cb_nav2z_client_behavior_base.hpp
@@ -22,102 +22,54 @@
 #include <cl_nav2z/cl_nav2z.hpp>
 #include <cl_nav2z/components/nav2_action_interface/cp_nav2_action_interface.hpp>
 #include <cl_nav2z/components/planner_switcher/cp_planner_switcher.hpp>
-#include <smacc2/client_core_components/cp_action_client.hpp>
-#include <smacc2/smacc_asynchronous_client_behavior.hpp>
+#include <smacc2/client_behavior_bases/cb_action_client_behavior_base.hpp>
 
 namespace cl_nav2z
 {
 using namespace smacc2;
-class CbNav2ZClientBehaviorBase : public smacc2::SmaccAsyncClientBehavior
+
+// Navigation behavior base, built on the generic action-client behavior
+// template: goal sending (server-ready guard + rejection watchdog), result
+// signal wiring (state machine thread), in-flight goal cancellation on early
+// state exit and EvCbSuccess/EvCbFailure termination all come from
+// CbActionClientBehaviorBase<NavigateToPose>. This class adds the
+// nav-domain component (CpNav2ActionInterface, which posts the machine-scoped
+// EvAction* navigation events) and keeps the historical nav-named result
+// virtuals for existing overriders.
+class CbNav2ZClientBehaviorBase
+: public smacc2::client_behavior_bases::CbActionClientBehaviorBase<nav2_msgs::action::NavigateToPose>
 {
+  using CbActionBase =
+    smacc2::client_behavior_bases::CbActionClientBehaviorBase<nav2_msgs::action::NavigateToPose>;
+
 public:
   virtual ~CbNav2ZClientBehaviorBase();
 
   template <typename TOrthogonal, typename TSourceObject>
   void onStateOrthogonalAllocation()
   {
-    // NEW: Pure component-based approach - no client dependencies
     this->requiresComponent(nav2ActionInterface_, ComponentRequirement::HARD);
-    this->requiresComponent(actionClient_, ComponentRequirement::HARD);
 
-    // Connect the action result signals here, on the state machine thread during
-    // state configuration: connecting from the behavior's asynchronous onEntry
-    // thread (as sendGoal used to) contends for the state machine mutex and can
-    // deadlock against a concurrent state transition.
-    if (!resultConnectionsInitialized_ && nav2ActionInterface_)
-    {
-      this->onNavigationSucceeded(&CbNav2ZClientBehaviorBase::onNavigationActionSuccess, this);
-      this->onNavigationAborted(&CbNav2ZClientBehaviorBase::onNavigationActionAbort, this);
-      this->onNavigationCancelled(&CbNav2ZClientBehaviorBase::onNavigationActionAbort, this);
-      resultConnectionsInitialized_ = true;
-    }
-
-    smacc2::SmaccAsyncClientBehavior::onStateOrthogonalAllocation<TOrthogonal, TSourceObject>();
+    // resolves actionClient_ and wires the result signals (see the template
+    // header for the threading rationale); chain-break => bad_function_call
+    CbActionBase::template onStateOrthogonalAllocation<TOrthogonal, TSourceObject>();
   }
 
 protected:
-  // Sends the goal through CpNav2ActionInterface. The action result signals are
-  // connected in onStateOrthogonalAllocation, so navigationResult_ is updated and
-  // EvCbSuccess/EvCbFailure are posted when the navigation finishes.
-  void sendGoal(nav2_msgs::action::NavigateToPose::Goal & goal);
-
-  void cancelGoal()
-  {
-    if (nav2ActionInterface_)
-    {
-      nav2ActionInterface_->cancelNavigation();
-    }
-  }
-
-  // Component-based signal connections
-  template <typename T>
-  smacc2::SmaccSignalConnection onNavigationSucceeded(
-    void (T::*callback)(const components::CpNav2ActionInterface::WrappedResult &), T * object)
-  {
-    if (nav2ActionInterface_)
-    {
-      return nav2ActionInterface_->onNavigationSucceeded(callback, object);
-    }
-    return smacc2::SmaccSignalConnection();
-  }
-
-  template <typename T>
-  smacc2::SmaccSignalConnection onNavigationAborted(
-    void (T::*callback)(const components::CpNav2ActionInterface::WrappedResult &), T * object)
-  {
-    if (nav2ActionInterface_)
-    {
-      return nav2ActionInterface_->onNavigationAborted(callback, object);
-    }
-    return smacc2::SmaccSignalConnection();
-  }
-
-  template <typename T>
-  smacc2::SmaccSignalConnection onNavigationCancelled(
-    void (T::*callback)(const components::CpNav2ActionInterface::WrappedResult &), T * object)
-  {
-    if (nav2ActionInterface_)
-    {
-      return nav2ActionInterface_->onNavigationCancelled(callback, object);
-    }
-    return smacc2::SmaccSignalConnection();
-  }
-
-  // NEW: Component references instead of client reference
-  components::CpNav2ActionInterface * nav2ActionInterface_ = nullptr;
-  smacc2::client_core_components::CpActionClient<nav2_msgs::action::NavigateToPose> *
-    actionClient_ = nullptr;
-
-  rclcpp_action::ResultCode navigationResult_ = rclcpp_action::ResultCode::UNKNOWN;
-
-  // Result handlers connected by sendGoal(). The base implementations store the
-  // result code and post the behavior success/failure events; derived classes may
-  // override to customize result handling (see CbNavigateNextWaypointUntilReached).
+  // Result handlers dispatched by the template. The base implementations
+  // record the result code and post the behavior success/failure events;
+  // derived classes may override to customize result handling (see
+  // CbNavigateNextWaypointUntilReached).
   virtual void onNavigationActionSuccess(const components::CpNav2ActionInterface::WrappedResult &);
   virtual void onNavigationActionAbort(const components::CpNav2ActionInterface::WrappedResult &);
 
-private:
-  bool resultConnectionsInitialized_ = false;
+  // route the template's result handlers into the nav-named virtuals
+  void onActionSuccess(const WrappedResult & result) override;
+  void onActionAbort(const WrappedResult & result) override;
+
+  components::CpNav2ActionInterface * nav2ActionInterface_ = nullptr;
+
+  rclcpp_action::ResultCode navigationResult_ = rclcpp_action::ResultCode::UNKNOWN;
 };
 
 enum class SpinningPlanner

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors/cb_undock_robot.hpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/include/cl_nav2z/client_behaviors/cb_undock_robot.hpp
@@ -1,0 +1,41 @@
+// Copyright 2026 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include <nav2_msgs/action/undock_robot.hpp>
+#include <smacc2/client_behavior_bases/cb_action_client_behavior_base.hpp>
+
+namespace cl_nav2z
+{
+
+// Undock the robot via the Nav2 docking server (opennav_docking): back out of
+// the dock the robot is currently on. dockType selects the dock plugin when
+// the server can't infer it from the last docking action.
+class CbUndockRobot
+: public smacc2::client_behavior_bases::CbActionClientBehaviorBase<nav2_msgs::action::UndockRobot>
+{
+public:
+  explicit CbUndockRobot(std::string dockType = "", float maxUndockingTime = 30.0f);
+
+  void onEntry() override;
+
+private:
+  std::string dockType_;
+  float maxUndockingTime_;
+};
+
+}  // namespace cl_nav2z

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_assisted_teleop.cpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_assisted_teleop.cpp
@@ -1,0 +1,37 @@
+// Copyright 2026 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cl_nav2z/client_behaviors/cb_assisted_teleop.hpp>
+
+namespace cl_nav2z
+{
+
+CbAssistedTeleop::CbAssistedTeleop(std::chrono::seconds timeAllowance)
+: timeAllowance_(timeAllowance)
+{
+}
+
+void CbAssistedTeleop::onEntry()
+{
+  Goal goal;
+  goal.time_allowance = rclcpp::Duration(timeAllowance_);
+
+  RCLCPP_INFO(
+    getLogger(), "[%s] Assisted teleop for %ld s (collision-guarded, behavior server)",
+    getName().c_str(), static_cast<long>(timeAllowance_.count()));
+
+  sendGoal(goal);
+}
+
+}  // namespace cl_nav2z

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_dock_robot.cpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_dock_robot.cpp
@@ -1,0 +1,48 @@
+// Copyright 2026 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cl_nav2z/client_behaviors/cb_dock_robot.hpp>
+
+namespace cl_nav2z
+{
+
+CbDockRobot::CbDockRobot(std::string dockId) : useDockId_(true), dockId_(std::move(dockId)) {}
+
+CbDockRobot::CbDockRobot(geometry_msgs::msg::PoseStamped dockPose, std::string dockType)
+: useDockId_(false), dockPose_(std::move(dockPose)), dockType_(std::move(dockType))
+{
+}
+
+void CbDockRobot::onEntry()
+{
+  Goal goal;
+  goal.use_dock_id = useDockId_;
+  if (useDockId_)
+  {
+    goal.dock_id = dockId_;
+    RCLCPP_INFO(getLogger(), "[%s] Docking at dock '%s'", getName().c_str(), dockId_.c_str());
+  }
+  else
+  {
+    goal.dock_pose = dockPose_;
+    goal.dock_type = dockType_;
+    RCLCPP_INFO(
+      getLogger(), "[%s] Docking at pose [%.2f, %.2f] (type '%s')", getName().c_str(),
+      dockPose_.pose.position.x, dockPose_.pose.position.y, dockType_.c_str());
+  }
+
+  sendGoal(goal);
+}
+
+}  // namespace cl_nav2z

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_nav2z_client_behavior_base.cpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_nav2z_client_behavior_base.cpp
@@ -17,6 +17,7 @@
  * 	 Authors: Pablo Inigo Blasco, Brett Aldrich
  *
  ******************************************************************************************************************/
+
 #include <cl_nav2z/client_behaviors/cb_nav2z_client_behavior_base.hpp>
 #include <cl_nav2z/common.hpp>
 
@@ -24,33 +25,30 @@ namespace cl_nav2z
 {
 CbNav2ZClientBehaviorBase::~CbNav2ZClientBehaviorBase() {}
 
-void CbNav2ZClientBehaviorBase::sendGoal(nav2_msgs::action::NavigateToPose::Goal & goal)
+void CbNav2ZClientBehaviorBase::onActionSuccess(const WrappedResult & r)
 {
-  if (!nav2ActionInterface_)
-  {
-    RCLCPP_ERROR(
-      getLogger(), "[%s] Cannot send goal, CpNav2ActionInterface not available", getName().c_str());
-    return;
-  }
+  navigationResult_ = r.code;
+  actionResult_ = r.code;
+  this->onNavigationActionSuccess(r);
+}
 
-  // result signal connections are established in onStateOrthogonalAllocation
-  // (state machine thread) - see the header for the threading rationale
-  RCLCPP_INFO_STREAM(getLogger(), "[" << getName() << "] Sending goal");
-  nav2ActionInterface_->sendGoal(goal);
+void CbNav2ZClientBehaviorBase::onActionAbort(const WrappedResult & r)
+{
+  navigationResult_ = r.code;
+  actionResult_ = r.code;
+  this->onNavigationActionAbort(r);
 }
 
 void CbNav2ZClientBehaviorBase::onNavigationActionSuccess(
-  const components::CpNav2ActionInterface::WrappedResult & r)
+  const components::CpNav2ActionInterface::WrappedResult &)
 {
-  navigationResult_ = r.code;
   RCLCPP_INFO(getLogger(), "[%s] Propagating success event from action server", getName().c_str());
   this->postSuccessEvent();
 }
 
 void CbNav2ZClientBehaviorBase::onNavigationActionAbort(
-  const components::CpNav2ActionInterface::WrappedResult & r)
+  const components::CpNav2ActionInterface::WrappedResult &)
 {
-  navigationResult_ = r.code;
   RCLCPP_INFO(getLogger(), "[%s] Propagating failure event from action server", getName().c_str());
   this->postFailureEvent();
 }

--- a/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_undock_robot.cpp
+++ b/smacc2_client_library/cl_nav2z/cl_nav2z/src/cl_nav2z/client_behaviors/cb_undock_robot.cpp
@@ -1,0 +1,38 @@
+// Copyright 2026 RobosoftAI Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cl_nav2z/client_behaviors/cb_undock_robot.hpp>
+
+namespace cl_nav2z
+{
+
+CbUndockRobot::CbUndockRobot(std::string dockType, float maxUndockingTime)
+: dockType_(std::move(dockType)), maxUndockingTime_(maxUndockingTime)
+{
+}
+
+void CbUndockRobot::onEntry()
+{
+  Goal goal;
+  goal.dock_type = dockType_;
+  goal.max_undocking_time = maxUndockingTime_;
+
+  RCLCPP_INFO(
+    getLogger(), "[%s] Undocking (type '%s', max %.1f s)", getName().c_str(), dockType_.c_str(),
+    static_cast<double>(maxUndockingTime_));
+
+  sendGoal(goal);
+}
+
+}  // namespace cl_nav2z


### PR DESCRIPTION
**Rebase the Nav2 behavior base onto the action-client template, named component addressing, docking/teleop wrappers**

This PR completes the follow-up items deferred from the behavior-base rollout (#779): the navigation base becomes a consumer of the core template instead of a parallel implementation, the multi-instance component addressing gap is closed, the remaining Nav2 server actions get wrappers, and the regression gate that validated the rebase caught — and this PR fixes — a real executor-starvation bug in the template's goal-response handling.

**CbNav2ZClientBehaviorBase rebased onto CbActionClientBehaviorBase<NavigateToPose>**

The navigation base carried its own copy of the machinery the template now provides: component resolution, result-signal wiring on the state machine thread, goal cancellation. Deriving from the template deletes that duplication and gives every navigation behavior the template's guards for free — a server-not-ready check, a goal-rejection failure path, and cancellation of in-flight goals on early state exit, none of which the old base had. Compatibility is preserved deliberately: CpNav2ActionInterface is still resolved (it posts the machine-scoped EvAction* navigation events), the navigationResult_ member remains (read by CbUndoPathBackwards), and the nav-named result virtuals stay as the override points (CbNavigateNextWaypointUntilReached depends on them) — the template's handlers now route through them. The template also gained a hardening fix: result signals connect to private trampolines that clear the in-flight flag before dispatching, so a derived override that fully replaces result handling can no longer strand a completed goal as "in flight."

**Goal-response starvation fix (found by the regression gate)**

Re-running the full sm_nav2_gazebo_test_2 mission after the rebase, every navigation goal "timed out waiting for the goal response" at 10 s and failed the mission — while bt_navigator was demonstrably executing the goal. The diagnosis: during an active NavigateToPose goal, the action client's waitable (goal response and feedback callbacks) is starved under spin_some by the goal's own continuous feedback stream; plain subscriptions keep flowing, but the response only gets serviced once feedback stops at goal completion. The behavior-server primitives that originally validated the template trickle feedback, which is why this never surfaced before. The wait now treats observed feedback or a result as proof of acceptance, and if the window expires with no activity at all it logs a warning and assumes the goal is in flight, deferring to the result signals. Rejections still fail fast: a rejected goal produces no feedback, so nothing starves its response — proven live when an inactive bt_navigator rejected a goal and the failure event posted within 50 ms.

**Named component addressing**

Behaviors could only resolve components by type, so with several CpActionClient instances of the same action type under one client, requiresComponent always bound the first match. Core gains a requiresComponent(name, storage, requirement) overload forwarding to the existing named getComponent, and the template gains setActionClientName() so a wrapper can bind its named instance from its constructor (allocation runs before runtimeConfigure, so construction is the only correct time).

**New wrappers and doc fixes**

CbAssistedTeleop, CbDockRobot (dock-database id or explicit pose + dock type), and CbUndockRobot wrap the remaining behavior-server and docking-server actions, all present in Jazzy nav2_msgs. No in-tree SM runs a docking server yet, so their hooks and CpActionClient specializations were verified by explicit instantiation. The CLAUDE.md guidance files also drop long-stale names (CpMoveItInterface never existed; several pre-rename package paths).

**Validation**

sm_nav2_gazebo_test_2 full mission: 10/10 undo successes, 10 rotations, 10 forward legs, 5 global navigations, zero failures, clean finale. sm_nav2_gazebo_test_3: all twelve primitive goals accepted through the normal response path (zero starvation fallbacks, confirming the mechanism analysis), collision-abort leg intact. Both missions match their pre-rebase baselines exactly.